### PR TITLE
new theme: Campbell

### DIFF
--- a/themes/Campbell.conf
+++ b/themes/Campbell.conf
@@ -1,0 +1,46 @@
+# vim:ft=kitty
+
+## name: Campbell
+## blurb: The default theme of Microsoft's terminals, including Windows Terminal and cmd.
+
+# The basic colors
+foreground                      #cccccc
+background                      #0c0c0c
+selection_background            #ffffff
+
+# Cursor colors
+cursor                          #ffffff
+
+# The basic 16 colors
+# black
+color0 #0c0c0c
+color8 #767676
+
+# red
+color1 #c50f1f
+color9 #e74856
+
+# green
+color2  #13a10e
+color10 #16c60c
+
+# yellow
+color3  #f19c00
+color11 #f9f1a5
+
+# blue
+color4  #0037da
+color12 #3b78ff
+
+# magenta
+color5  #881798
+color13 #b4009e
+
+# cyan
+color6  #3a96dd
+color14 #61d6d6
+
+# white
+color7  #cccccc
+color15 #f2f2f2
+


### PR DESCRIPTION
Campbell is the default theme of Windows Terminal and cmd. I'm not really sure how ownership works when it comes to themes like this (such as whether the author should be Microsoft or me, who only ported it), so I've left those fields out. Just tell me if something needs to be fixed and I'll take care of it.

For reference:
https://docs.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes
https://devblogs.microsoft.com/commandline/updating-the-windows-console-colors/