### PR TITLE
fix(srcery): sync colors with upstream

### DIFF
--- a/themes/Srcery.conf
+++ b/themes/Srcery.conf
@@ -13,7 +13,7 @@ selection_background #FCE8C3
 
 # Black
 color0               #1C1B19
-color8               #2D2C29
+color8               #918175
 
 # Red
 color1               #EF2F27
@@ -37,8 +37,8 @@ color13              #FF5C8F
 
 # Cyan
 color6               #0AAEB3
-color14              #53FDE9
+color14              #2BE4D0
 
 # White
-color7               #918175
+color7               #BAA67F
 color15              #FCE8C3


### PR DESCRIPTION
Some colors are changes since they were included in the old collection.

## Changes

* [Black](https://github.com/srcery-colors/srcery-terminal/commit/a597e242edb792aa9fb8a20160a242c0ae64d1d3#diff-2b68a7150c629bb6fb90fe204e947c07c783d7e240b0f5df0b44c5bdb24d652d)
* [White](https://github.com/srcery-colors/srcery-terminal/commit/f3e2ee49960c5be19664d725d9fd5588379b141c#diff-2b68a7150c629bb6fb90fe204e947c07c783d7e240b0f5df0b44c5bdb24d652d)
* [Cyan](https://github.com/srcery-colors/srcery-terminal/commit/566eb23e7bbf084bb56587a08ba2df6cb65db5a8#diff-2b68a7150c629bb6fb90fe204e947c07c783d7e240b0f5df0b44c5bdb24d652d)