### PR TITLE
'wizzy' theme submission

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -1224,6 +1224,18 @@
         "num_settings": 21
     },
     {
+        "file": "themes/wizzy-bright.conf",
+        "is_dark": true,
+        "name": "Wizzy Bright",
+        "num_settings": 26
+    },
+    {
+        "file": "themes/wizzy-muted.conf",
+        "is_dark": true,
+        "name": "Wizzy Muted",
+        "num_settings": 26
+    },
+    {
         "file": "themes/Wombat.conf",
         "is_dark": true,
         "name": "Wombat",

--- a/themes/wizzy-bright.conf
+++ b/themes/wizzy-bright.conf
@@ -1,0 +1,57 @@
+# vim:ft=kitty
+
+## name: Wizzy Bright
+## license: MIT
+## author: erin
+## upstream: https://github.com/erincerys/kitty-themes/blob/master/themes/wizzy-bright.conf
+## blurb: A variant of Wryan for a certain special Lain
+
+background              #100814
+selection_background    #4d4d4d
+cursor                  #9d9eca
+
+# a nearly imperceptible purple
+foreground              #b2b8c4
+# alternate, deeper shades of purple
+#foreground              #8a8dae
+#foreground              #9b9ebf
+url_color               #75c8c8
+selection_foreground    #101010
+
+# black
+color0                  #666666
+color8                  #6f6f6f
+
+# red
+color1                  #bf7998
+color9                  #cf7fb3
+
+# green
+color2                  #5ba6a6
+color10                 #75c8c8
+
+# yellow
+color3                  #8d8daa
+color11                 #afafdc
+
+# blue
+color4                  #6c88a6
+color12                 #7aade6
+
+# magenta
+color5                  #8f79bf
+color13                 #af95e6
+
+# cyan
+color6                  #6498bf
+color14                 #82b8df
+
+# white
+color7                  #abbec5
+color15                 #bccfd4
+
+# tab bar
+active_tab_foreground   #322a69
+active_tab_background   #afafdc
+inactive_tab_foreground #322a36
+inactive_tab_background #8d8daa

--- a/themes/wizzy-muted.conf
+++ b/themes/wizzy-muted.conf
@@ -1,0 +1,57 @@
+# vim:ft=kitty
+
+## name: Wizzy Muted
+## license: MIT
+## author: erin
+## upstream: https://github.com/erincerys/kitty-themes/blob/master/themes/wizzy-muted.conf
+## blurb: A variant of Wryan for a certain special Lain
+
+background              #100814
+selection_background    #4d4d4d
+cursor                  #9d9eca
+
+# a nearly imperceptible purple
+foreground              #b2b8c4
+# alternate, deeper shades of purple
+#foreground              #8a8dae
+#foreground              #9b9ebf
+url_color               #64b7b7
+selection_foreground    #101010
+
+# black
+color0                  #444444
+color8                  #4e4e4e
+
+# red
+color1                  #9d5776
+color9                  #cf5e91
+
+# green
+color2                  #398484
+color10                 #64b7b7
+
+# yellow
+color3                  #6b6b88
+color11                 #8d8dba
+
+# blue
+color4                  #4a6684
+color12                 #588bc4
+
+# magenta
+color5                  #6f579d
+color13                 #8f73c4
+
+# cyan
+color6                  #42769d
+color14                 #71a7cf
+
+# white
+color7                  #9aadb2
+color15                 #d1d1d1
+
+# tab bar
+active_tab_foreground   #100847
+active_tab_background   #8d8dba
+inactive_tab_foreground #100814
+inactive_tab_background #6b6b88


### PR DESCRIPTION
Submission of a new theme set named Wizzy. There are two variants, where the difference is in brightness of text, hence the naming. However, they are both dark themes.

Inspiration for this came from Wryan, for which they are both heavily based on the primary colors of.

I have updated the repo themes metadata, and conformed the theme files to the template.