### PR TITLE
Add option tab_bar_margin_color

### DIFF
--- a/template.conf
+++ b/template.conf
@@ -1,7 +1,7 @@
 # vim:ft=kitty
-# This is a template that can be used to create new kitty themes.
-# Theme files should start with a metadata block consisting of
-# lines beginning with ##. All metadata fields are optional.
+#: This is a template that can be used to create new kitty themes.
+#: Theme files should start with a metadata block consisting of
+#: lines beginning with ##. All metadata fields are optional.
 
 ## name: The name of the theme (if not present, derived from filename)
 ## author: The name of the theme author
@@ -10,35 +10,46 @@
 ## blurb: A description of this theme. This must be the
 ## last item in the metadata and can continue over multiple lines.
 
-# All the settings below are colors, which you can choose to modify, or use the
-# defaults. You can also add non-color based settings if needed but note that
-# these will not work with using kitty @ set-colors with this theme. For a reference
-# on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
 
-# The basic colors
+#: The basic colors
+
 # foreground                      #dddddd
 # background                      #000000
 # selection_foreground            #000000
 # selection_background            #fffacd
 
-# Cursor colors
+
+#: Cursor colors
+
 # cursor                          #cccccc
 # cursor_text_color               #111111
 
-# URL underline color when hovering with mouse
+
+#: URL underline color when hovering with mouse
+
 # url_color                       #0087bd
 
-# kitty window border colors and terminal bell colors
+
+#: kitty window border colors and terminal bell colors
+
 # active_border_color             #00ff00
 # inactive_border_color           #cccccc
 # bell_border_color               #ff5a00
 # visual_bell_color               none
 
-# OS Window titlebar colors
+
+#: OS Window titlebar colors
+
 # wayland_titlebar_color          system
 # macos_titlebar_color            system
 
-# Tab bar colors
+
+#: Tab bar colors
+
 # active_tab_foreground           #000
 # active_tab_background           #eee
 # inactive_tab_foreground         #444
@@ -46,7 +57,8 @@
 # tab_bar_background              none
 # tab_bar_margin_color            none
 
-# Colors for marks (marked text in the terminal)
+
+#: Colors for marks (marked text in the terminal)
 
 # mark1_foreground black
 # mark1_background #98d3cb
@@ -56,45 +68,39 @@
 # mark3_background #f274bc
 
 
-# The basic 16 colors
-# black
+#: The basic 16 colors
+
+#: black
 # color0 #000000
 # color8 #767676
 
-
-# red
+#: red
 # color1 #cc0403
 # color9 #f2201f
 
-
-# green
+#: green
 # color2  #19cb00
 # color10 #23fd00
 
-
-# yellow
+#: yellow
 # color3  #cecb00
 # color11 #fffd00
 
-
-# blue
+#: blue
 # color4  #0d73cc
 # color12 #1a8fff
 
-
-# magenta
+#: magenta
 # color5  #cb1ed1
 # color13 #fd28ff
 
-
-# cyan
+#: cyan
 # color6  #0dcdcd
 # color14 #14ffff
 
-
-# white
+#: white
 # color7  #dddddd
 # color15 #ffffff
 
 
-# You can set the remaining 240 colors as color16 to color255.
+#: You can set the remaining 240 colors as color16 to color255.

--- a/template.conf
+++ b/template.conf
@@ -44,6 +44,7 @@
 # inactive_tab_foreground         #444
 # inactive_tab_background         #999
 # tab_bar_background              none
+# tab_bar_margin_color            none
 
 # Colors for marks (marked text in the terminal)
 


### PR DESCRIPTION
Adds the new `tab_bar_margin_color` option to the template.

Use `#:` starters for document lines and adjust the blank line spacing.