### PR TITLE
Add srcery contrast theme

### DIFF
--- a/themes/Srcery-Contrast.conf
+++ b/themes/Srcery-Contrast.conf
@@ -1,0 +1,72 @@
+# vim:ft=kitty
+
+## name: Srcery Contrast
+
+#: The basic colors
+
+foreground                      #fce8c3
+background                      #1c1b19
+selection_foreground            #1c1b19
+selection_background            #fce8c3
+
+
+#: Cursor colors
+
+cursor                          #c0aa9b
+cursor_text_color               #1c1b19
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #2c78bf
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #519f50
+inactive_border_color           #fce8c3
+bell_border_color               #519f50
+
+
+#: Tab bar colors
+
+active_tab_foreground           #fce8c3
+active_tab_background           #6c6962
+inactive_tab_foreground         #c0aa9b
+inactive_tab_background         #6c6962
+tab_bar_background              #6c6962
+
+
+#: The basic 16 colors
+
+#: black
+color0 #494641
+color8 #6c6962
+
+#: red
+color1 #ef2f27
+color9 #f75341
+
+#: green
+color2  #519f50
+color10 #98bc37
+
+#: yellow
+color3  #fbb829
+color11 #fed06e
+
+#: blue
+color4  #2c78bf
+color12 #68a8e4
+
+#: magenta
+color5  #e02c6d
+color13 #ff5c8f
+
+#: cyan
+color6  #0aaeb3
+color14 #53fde9
+
+#: white
+color7  #c0aa9b
+color15 #fce8c3


### PR DESCRIPTION
This adds a variation of the Srcery theme that has better contrast. Certain colors weren't visible against the background with the regular Srcery theme from this repo. I've tried to stay as close as possible to the original Srcery theme, without sacrificing legibility.