### PR TITLE
Use true Solarized Light colors

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -1224,7 +1224,10 @@
         "num_settings": 21
     },
     {
+        "author": "Ethan Schoonover",
+        "blurb": "Precision colors for machines and people",
         "file": "themes/Solarized_Dark.conf",
+        "license": "MIT",
         "is_dark": true,
         "name": "Solarized Dark",
         "num_settings": 21
@@ -1242,7 +1245,10 @@
         "num_settings": 21
     },
     {
+        "author": "Ethan Schoonover",
+        "blurb": "Precision colors for machines and people",
         "file": "themes/Solarized_Light.conf",
+        "license": "MIT",
         "name": "Solarized Light",
         "num_settings": 26
     },

--- a/themes/Solarized_Dark.conf
+++ b/themes/Solarized_Dark.conf
@@ -1,3 +1,10 @@
+# vim:ft=kitty
+
+## name: Solarized Dark
+## author: Ethan Schoonover
+## license: MIT
+## blurb: Precision colors for machines and people
+
 background #002b36
 foreground #839496
 cursor #708183

--- a/themes/Solarized_Light.conf
+++ b/themes/Solarized_Light.conf
@@ -1,28 +1,59 @@
-background            #fdf6e3
-foreground            #52676f
-cursor                #52676f
-selection_background  #e9e2cb
-selection_foreground  #262626
-color0 #e4e4e4
-color8 #ffffd7
-color1 #d70000
-color9 #d75f00
-color2 #5f8700
-color10 #585858
-color3 #af8700
-color11 #626262
-color4 #0087ff
-color12 #808080
-color5 #af005f
-color13 #5f5faf
-color6 #00afaf
-color14 #8a8a8a
-color7 #262626
-color15 #1c1c1c
+# vim:ft=kitty
 
-active_tab_foreground #262626
-active_tab_background #e4e4e4
-inactive_tab_foreground #262626
-inactive_tab_background #ffffd7
+## name: Solarized Light
+## author: Ethan Schoonover
+## license: MIT
+## blurb: Precision colors for machines and people
 
-active_border_color #d75f00
+# The basic colors
+foreground              #657b83
+background              #fdf6e3
+selection_foreground    #586e75
+selection_background    #eee8d5
+
+# Cursor colors
+cursor                  #657b83
+cursor_text_color       #fdf6e3
+
+# kitty window border colors
+active_border_color     #cb4b16
+inactive_border_color   #93a1a1
+
+# Tab bar colors
+active_tab_background   #fdf6e3
+active_tab_foreground   #657b83
+inactive_tab_background #93a1a1
+inactive_tab_foreground #fdf6e3
+
+# The basic 16 colors
+# black
+color0 #073642
+color8 #93a1a1
+
+# red
+color1 #dc322f
+color9 #cb4b16
+
+# green
+color2  #859900
+color10 #586e75
+
+# yellow
+color3  #b58900
+color11 #657b83
+
+# blue
+color4  #268bd2
+color12 #839496
+
+# magenta
+color5  #d33682
+color13 #6c71c4
+
+# cyan
+color6  #2aa198
+color14 #93a1a1
+
+# white
+color7  #eee8d5
+color15 #fdf6e3


### PR DESCRIPTION
Hello! 

This is a small rework, since I noticed that currently Solarized Light version available in kitty-themes repository is not true to the original. I have also updated it with information about license and author.

As could be inspected in provided link, Solarized [explicitly defines][1] background and foreground colors:
* #fdf6e3 (base 3) for background
* #657b83 (base 00) for primary content
* #93a1a1 (base 1) for comments/secondary content
* #eee8d5 (base 2) for background highlights
* #586e75 (base 01) for emphasized content

[1]: https://ethanschoonover.com/solarized/#usage-development


Best regards,
alternateved