### PR TITLE
onehalf: Update color8 to match upstream

### DIFF
--- a/themes/OneHalf.conf
+++ b/themes/OneHalf.conf
@@ -10,7 +10,7 @@ url_color             #0087BD
 
 # black
 color0   #282c34
-color8   #282c36
+color8   #5d677a
 
 # red
 color1   #e06c75


### PR DESCRIPTION
In sonph/onehalf#92 (upstream theme), "bright black" was set to a different shade of gray from "black".