### PR TITLE
Remove markdown formatting from licenses

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -1086,7 +1086,7 @@
         "blurb": "Dark color scheme inspired by Google's Material Design",
         "file": "themes/PaperColor_dark.conf",
         "is_dark": true,
-        "license": "[MIT License](https://opensource.org/licenses/MIT)",
+        "license": "MIT",
         "name": "PaperColor Dark",
         "num_settings": 20
     },
@@ -1094,7 +1094,7 @@
         "author": "Nikyle Nguyen",
         "blurb": "Light color scheme inspired by Google's Material Design",
         "file": "themes/PaperColor_light.conf",
-        "license": "[MIT License](https://opensource.org/licenses/MIT)",
+        "license": "MIT",
         "name": "PaperColor Light",
         "num_settings": 20
     },
@@ -1647,7 +1647,7 @@
         "blurb": "A port of moonlight vscode extension for kitty terminal",
         "file": "themes/moonlight.conf",
         "is_dark": true,
-        "license": "MIT License",
+        "license": "MIT",
         "name": "moonlight",
         "num_settings": 29,
         "upstream": "https://raw.githubusercontent.com/ramonsaraiva/kitty-moonlight/main/moonlight.conf"

--- a/themes/PaperColor_dark.conf
+++ b/themes/PaperColor_dark.conf
@@ -2,7 +2,7 @@
 
 ## name: PaperColor Dark
 ## author: Nikyle Nguyen
-## license: [MIT License](https://opensource.org/licenses/MIT)
+## license: MIT
 ## blurb: Dark color scheme inspired by Google's Material Design 
 
 # special

--- a/themes/PaperColor_light.conf
+++ b/themes/PaperColor_light.conf
@@ -2,7 +2,7 @@
 
 ## name: PaperColor Light
 ## author: Nikyle Nguyen
-## license: [MIT License](https://opensource.org/licenses/MIT)
+## license: MIT
 ## blurb: Light color scheme inspired by Google's Material Design 
 
 # special

--- a/themes/moonlight.conf
+++ b/themes/moonlight.conf
@@ -2,7 +2,7 @@
 
 ## name: moonlight
 ## author: Ramon Saraiva
-## license: MIT License
+## license: MIT
 ## upstream: https://raw.githubusercontent.com/ramonsaraiva/kitty-moonlight/main/moonlight.conf
 ## blurb: A port of moonlight vscode extension for kitty terminal
 


### PR DESCRIPTION
It looks like the license format I used in my previous PR was wrong.

This PR fixes the few occurrences that include markdown in their "license" attribute.