### PR TITLE
Update Gruvbox Material themes

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -610,37 +610,61 @@
         "upstream": "https://raw.githubusercontent.com/gruvbox-community/gruvbox-contrib/master/kitty/gruvbox-light-soft.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialDarkHard.conf",
         "is_dark": true,
+        "license": "MIT",
         "name": "Gruvbox Material Dark Hard",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-hard.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialDarkMedium.conf",
         "is_dark": true,
+        "license": "MIT",
         "name": "Gruvbox Material Dark Medium",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-medium.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialDarkSoft.conf",
         "is_dark": true,
+        "license": "MIT",
         "name": "Gruvbox Material Dark Soft",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-soft.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialLightHard.conf",
+        "license": "MIT",
         "name": "Gruvbox Material Light Hard",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-hard.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialLightMedium.conf",
+        "license": "MIT",
         "name": "Gruvbox Material Light Medium",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-medium.conf"
     },
     {
+        "author": "Sainnhe Park",
+        "blurb": "A modified version of Gruvbox with softer contrasts",
         "file": "themes/GruvboxMaterialLightSoft.conf",
+        "license": "MIT",
         "name": "Gruvbox Material Light Soft",
-        "num_settings": 26
+        "num_settings": 22,
+        "upstream": "https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-soft.conf"
     },
     {
         "author": "Mert18",

--- a/themes/GruvboxMaterialDarkHard.conf
+++ b/themes/GruvboxMaterialDarkHard.conf
@@ -1,18 +1,18 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Dark Hard
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-hard.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #1d2021
-foreground #dfbf8e
+foreground #d4be98
 
-selection_background #dfbf8e
+selection_background #d4be98
 selection_foreground #1d2021
 
-active_tab_background   #1d2021
-active_tab_foreground   #dfbf8e
-active_tab_font_style   bold-italic
-inactive_tab_background #1d2021
-inactive_tab_foreground #a89984
-inactive_tab_font_style normal
+cursor #a89984
+cursor_text_color background
 
 # Black
 color0 #665c54
@@ -28,7 +28,7 @@ color10 #a9b665
 
 # Yellow
 color3  #e78a4e
-color11 #e3a84e
+color11 #d8a657
 
 # Blue
 color4  #7daea3
@@ -43,5 +43,5 @@ color6  #89b482
 color14 #89b482
 
 # White
-color7  #dfbf8e
-color15 #dfbf8e
+color7  #d4be98
+color15 #d4be98

--- a/themes/GruvboxMaterialDarkMedium.conf
+++ b/themes/GruvboxMaterialDarkMedium.conf
@@ -1,18 +1,18 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Dark Medium
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-medium.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #282828
-foreground #dfbf8e
+foreground #d4be98
 
-selection_background #dfbf8e
+selection_background #d4be98
 selection_foreground #282828
 
-active_tab_background   #282828
-active_tab_foreground   #dfbf8e
-active_tab_font_style   bold-italic
-inactive_tab_background #282828
-inactive_tab_foreground #a89984
-inactive_tab_font_style normal
+cursor #a89984
+cursor_text_color background
 
 # Black
 color0 #665c54
@@ -28,7 +28,7 @@ color10 #a9b665
 
 # Yellow
 color3  #e78a4e
-color11 #e3a84e
+color11 #d8a657
 
 # Blue
 color4  #7daea3
@@ -43,5 +43,5 @@ color6  #89b482
 color14 #89b482
 
 # White
-color7  #dfbf8e
-color15 #dfbf8e
+color7  #d4be98
+color15 #d4be98

--- a/themes/GruvboxMaterialDarkSoft.conf
+++ b/themes/GruvboxMaterialDarkSoft.conf
@@ -1,18 +1,18 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Dark Soft
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-dark-soft.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #32302f
-foreground #dfbf8e
+foreground #d4be98
 
-selection_background #dfbf8e
+selection_background #d4be98
 selection_foreground #32302f
 
-active_tab_background   #32302f
-active_tab_foreground   #dfbf8e
-active_tab_font_style   bold-italic
-inactive_tab_background #32302f
-inactive_tab_foreground #a89984
-inactive_tab_font_style normal
+cursor #a89984
+cursor_text_color background
 
 # Black
 color0 #665c54
@@ -28,7 +28,7 @@ color10 #a9b665
 
 # Yellow
 color3  #e78a4e
-color11 #e3a84e
+color11 #d8a657
 
 # Blue
 color4  #7daea3
@@ -43,5 +43,5 @@ color6  #89b482
 color14 #89b482
 
 # White
-color7  #dfbf8e
-color15 #dfbf8e
+color7  #d4be98
+color15 #d4be98

--- a/themes/GruvboxMaterialLightHard.conf
+++ b/themes/GruvboxMaterialLightHard.conf
@@ -1,38 +1,38 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Light Hard
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-hard.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #f9f5d7
-foreground #764e37
+foreground #654735
 
-selection_background #764e37
+selection_background #654735
 selection_foreground #f9f5d7
 
-active_tab_background   #f9f5d7
-active_tab_foreground   #764e37
-active_tab_font_style   bold-italic
-inactive_tab_background #f9f5d7
-inactive_tab_foreground #7c6f64
-inactive_tab_font_style normal
+cursor #928374
+cursor_text_color background
 
 # Black
 color0 #bdae93
 color8 #928374
 
 # Red
-color1 #c74545
-color9 #c74545
+color1 #c14a4a
+color9 #c14a4a
 
 # Green
 color2  #6c782e
 color10 #6c782e
 
 # Yellow
-color3  #c55b03
+color3  #c35e0a
 color11 #b47109
 
 # Blue
-color4  #47747e
-color12 #47747e
+color4  #45707a
+color12 #45707a
 
 # Magenta
 color5  #945e80
@@ -43,5 +43,5 @@ color6  #4c7a5d
 color14 #4c7a5d
 
 # White
-color7  #764e37
-color15 #764e37
+color7  #654735
+color15 #654735

--- a/themes/GruvboxMaterialLightMedium.conf
+++ b/themes/GruvboxMaterialLightMedium.conf
@@ -1,38 +1,38 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Light Medium
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-medium.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #fbf1c7
-foreground #764e37
+foreground #654735
 
-selection_background #764e37
+selection_background #654735
 selection_foreground #fbf1c7
 
-active_tab_background   #fbf1c7
-active_tab_foreground   #764e37
-active_tab_font_style   bold-italic
-inactive_tab_background #fbf1c7
-inactive_tab_foreground #7c6f64
-inactive_tab_font_style normal
+cursor #928374
+cursor_text_color background
 
 # Black
 color0 #bdae93
 color8 #928374
 
 # Red
-color1 #c74545
-color9 #c74545
+color1 #c14a4a
+color9 #c14a4a
 
 # Green
 color2  #6c782e
 color10 #6c782e
 
 # Yellow
-color3  #c55b03
+color3  #c35e0a
 color11 #b47109
 
 # Blue
-color4  #47747e
-color12 #47747e
+color4  #45707a
+color12 #45707a
 
 # Magenta
 color5  #945e80
@@ -43,5 +43,5 @@ color6  #4c7a5d
 color14 #4c7a5d
 
 # White
-color7  #764e37
-color15 #764e37
+color7  #654735
+color15 #654735

--- a/themes/GruvboxMaterialLightSoft.conf
+++ b/themes/GruvboxMaterialLightSoft.conf
@@ -1,38 +1,38 @@
-# GruvboxMaterial theme by sainnhe
-# License: [MIT License](https://opensource.org/licenses/MIT).
+# vim:ft=kitty
+## name: Gruvbox Material Light Soft
+## author: Sainnhe Park
+## license: MIT
+## upstream: https://raw.githubusercontent.com/rsaihe/gruvbox-material-kitty/main/colors/gruvbox-material-light-soft.conf
+## blurb: A modified version of Gruvbox with softer contrasts
 
 background #f2e5bc
-foreground #764e37
+foreground #654735
 
-selection_background #764e37
+selection_background #654735
 selection_foreground #f2e5bc
 
-active_tab_background   #f2e5bc
-active_tab_foreground   #764e37
-active_tab_font_style   bold-italic
-inactive_tab_background #f2e5bc
-inactive_tab_foreground #7c6f64
-inactive_tab_font_style normal
+cursor #928374
+cursor_text_color background
 
 # Black
 color0 #bdae93
 color8 #928374
 
 # Red
-color1 #c74545
-color9 #c74545
+color1 #c14a4a
+color9 #c14a4a
 
 # Green
 color2  #6c782e
 color10 #6c782e
 
 # Yellow
-color3  #c55b03
+color3  #c35e0a
 color11 #b47109
 
 # Blue
-color4  #47747e
-color12 #47747e
+color4  #45707a
+color12 #45707a
 
 # Magenta
 color5  #945e80
@@ -43,5 +43,5 @@ color6  #4c7a5d
 color14 #4c7a5d
 
 # White
-color7  #764e37
-color15 #764e37
+color7  #654735
+color15 #654735


### PR DESCRIPTION
- Add metadata (author, license, blurb, upstream), update `themes.json`
- Sync colors with [upstream](https://github.com/rsaihe/gruvbox-material-kitty/tree/d79d7c1f98078101cc4df9c759683c64ce749faa/colors) (the latest changes were contributed by the author of the color scheme)
- Remove tab and font attributes (I believe this kind of customizations should be at the discretion of the user, but I'm fine reverting them too)