### PR TITLE
Use strict upstream palettes in Everforest themes

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -414,7 +414,8 @@
         "num_settings": 21
     },
     {
-        "blurb": "Dark (hard) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_dark_hard.conf",
         "is_dark": true,
         "license": "MIT",
@@ -423,7 +424,8 @@
         "upstream": "https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_hard.conf"
     },
     {
-        "blurb": "Dark (medium) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_dark_medium.conf",
         "is_dark": true,
         "license": "MIT",
@@ -432,7 +434,8 @@
         "upstream": "https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_medium.conf"
     },
     {
-        "blurb": "Dark (soft) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_dark_soft.conf",
         "is_dark": true,
         "license": "MIT",
@@ -441,7 +444,8 @@
         "upstream": "https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_soft.conf"
     },
     {
-        "blurb": "Light (hard) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_light_hard.conf",
         "license": "MIT",
         "name": "Everforest Light Hard",
@@ -449,7 +453,8 @@
         "upstream": "https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_light_hard.conf"
     },
     {
-        "blurb": "Light (medium) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_light_medium.conf",
         "license": "MIT",
         "name": "Everforest Light Medium",
@@ -457,7 +462,8 @@
         "upstream": "https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_light_medium.conf"
     },
     {
-        "blurb": "Light (soft) theme based on https://github.com/sainnhe/everforest for Vim.",
+        "author": "Sainnhe Park",
+        "blurb": "A green based color scheme designed to be warm and soft",
         "file": "themes/everforest_light_soft.conf",
         "license": "MIT",
         "name": "Everforest Light Soft",

--- a/themes/everforest_dark_hard.conf
+++ b/themes/everforest_dark_hard.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Dark Hard
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_hard.conf
-## blurb: Dark (hard) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
 background                      #2b3339
@@ -36,33 +38,33 @@ mark3_foreground                #2b3339
 mark3_background                #d699b6
 
 #: black
-color0                          #2b3339
-color8                          #7a8478
+color0                          #374247
+color8                          #404c51
 
 #: red
 color1                          #e67e80
-color9                          #e66868
+color9                          #e67e80
 
 #: green
 color2                          #a7c080
-color10                         #8da101
+color10                         #a7c080
 
 #: yellow
 color3                          #dbbc7f
-color11                         #dfa000
+color11                         #dbbc7f
 
 #: blue
 color4                          #7fbbb3
-color12                         #3a94c5
+color12                         #7fbbb3
 
 #: magenta
 color5                          #d699b6
-color13                         #df69ba
+color13                         #d699b6
 
 #: cyan
 color6                          #83c092
-color14                         #35a77c
+color14                         #83c092
 
 #: white
-color7                          #d3c6aa
-color15                         #5c6a72
+color7                          #859289
+color15                         #9da9a0

--- a/themes/everforest_dark_medium.conf
+++ b/themes/everforest_dark_medium.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Dark Medium
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_medium.conf
-## blurb: Dark (medium) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
 background                      #2f383e
@@ -36,33 +38,33 @@ mark3_foreground                #2f383e
 mark3_background                #d699b6
 
 #: black
-color0                          #2f383e
-color8                          #7a8478
+color0                          #374247
+color8                          #404c51
 
 #: red
 color1                          #e67e80
-color9                          #e66868
+color9                          #e67e80
 
 #: green
 color2                          #a7c080
-color10                         #8da101
+color10                         #a7c080
 
 #: yellow
 color3                          #dbbc7f
-color11                         #dfa000
+color11                         #dbbc7f
 
 #: blue
 color4                          #7fbbb3
-color12                         #3a94c5
+color12                         #7fbbb3
 
 #: magenta
 color5                          #d699b6
-color13                         #df69ba
+color13                         #d699b6
 
 #: cyan
 color6                          #83c092
-color14                         #35a77c
+color14                         #83c092
 
 #: white
-color7                          #d3c6aa
-color15                         #5c6a72
+color7                          #859289
+color15                         #9da9a0

--- a/themes/everforest_dark_soft.conf
+++ b/themes/everforest_dark_soft.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Dark Soft
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_dark_soft.conf
-## blurb: Dark (soft) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
 background                      #323d43
@@ -36,33 +38,33 @@ mark3_foreground                #323d43
 mark3_background                #d699b6
 
 #: black
-color0                          #323d43
-color8                          #7a8478
+color0                          #374247
+color8                          #404c51
 
 #: red
 color1                          #e67e80
-color9                          #e66868
+color9                          #e67e80
 
 #: green
 color2                          #a7c080
-color10                         #8da101
+color10                         #a7c080
 
 #: yellow
 color3                          #dbbc7f
-color11                         #dfa000
+color11                         #dbbc7f
 
 #: blue
 color4                          #7fbbb3
-color12                         #3a94c5
+color12                         #7fbbb3
 
 #: magenta
 color5                          #d699b6
-color13                         #df69ba
+color13                         #d699b6
 
 #: cyan
 color6                          #83c092
-color14                         #35a77c
+color14                         #83c092
 
 #: white
-color7                          #d3c6aa
-color15                         #5c6a72
+color7                          #859289
+color15                         #9da9a0

--- a/themes/everforest_light_hard.conf
+++ b/themes/everforest_light_hard.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Light Hard
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_light_hard.conf
-## blurb: Light (hard) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #5c6a72
 background                      #fff9e8
@@ -36,33 +38,33 @@ mark3_foreground                #fff9e8
 mark3_background                #df69ba
 
 #: black
-color0                          #d3c6aa
-color8                          #a6b0a0
+color0                          #708089
+color8                          #829181
 
 #: red
-color1                          #e66868
-color9                          #e67e80
+color1                          #f85552
+color9                          #e66868
 
 #: green
 color2                          #8da101
-color10                         #a7c080
+color10                         #93b259
 
 #: yellow
 color3                          #dfa000
-color11                         #dbbc7f
+color11                         #dfa000
 
 #: blue
 color4                          #3a94c5
-color12                         #7fbbb3
+color12                         #3a94c5
 
 #: magenta
 color5                          #df69ba
-color13                         #d699b6
+color13                         #df69ba
 
 #: cyan
 color6                          #35a77c
-color14                         #83c092
+color14                         #35a77c
 
 #: white
-color7                          #5c6a72
-color15                         #d3c6aa
+color7                          #939f91
+color15                         #a6b0a0

--- a/themes/everforest_light_medium.conf
+++ b/themes/everforest_light_medium.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Light Medium
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_light_medium.conf
-## blurb: Light (medium) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #5c6a72
 background                      #fdf6e3
@@ -36,33 +38,33 @@ mark3_foreground                #fdf6e3
 mark3_background                #df69ba
 
 #: black
-color0                          #d3c6aa
-color8                          #a6b0a0
+color0                          #708089
+color8                          #829181
 
 #: red
-color1                          #e66868
-color9                          #e67e80
+color1                          #f85552
+color9                          #e66868
 
 #: green
 color2                          #8da101
-color10                         #a7c080
+color10                         #93b259
 
 #: yellow
 color3                          #dfa000
-color11                         #dbbc7f
+color11                         #dfa000
 
 #: blue
 color4                          #3a94c5
-color12                         #7fbbb3
+color12                         #3a94c5
 
 #: magenta
 color5                          #df69ba
-color13                         #d699b6
+color13                         #df69ba
 
 #: cyan
 color6                          #35a77c
-color14                         #83c092
+color14                         #35a77c
 
 #: white
-color7                          #5c6a72
-color15                         #d3c6aa
+color7                          #939f91
+color15                         #a6b0a0

--- a/themes/everforest_light_soft.conf
+++ b/themes/everforest_light_soft.conf
@@ -1,7 +1,9 @@
+# vim:ft=kitty
 ## name: Everforest Light Soft
+## author: Sainnhe Park
 ## license: MIT
 ## upstream: https://github.com/ewal/kitty-everforest/blob/master/themes/everforest_light_soft.conf
-## blurb: Light (soft) theme based on https://github.com/sainnhe/everforest for Vim.
+## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #5c6a72
 background                      #f8f0dc
@@ -36,33 +38,33 @@ mark3_foreground                #f8f0dc
 mark3_background                #df69ba
 
 #: black
-color0                          #d3c6aa
-color8                          #a6b0a0
+color0                          #708089
+color8                          #829181
 
 #: red
-color1                          #e66868
-color9                          #e67e80
+color1                          #f85552
+color9                          #e66868
 
 #: green
 color2                          #8da101
-color10                         #a7c080
+color10                         #93b259
 
 #: yellow
 color3                          #dfa000
-color11                         #dbbc7f
+color11                         #dfa000
 
 #: blue
 color4                          #3a94c5
-color12                         #7fbbb3
+color12                         #3a94c5
 
 #: magenta
 color5                          #df69ba
-color13                         #d699b6
+color13                         #df69ba
 
 #: cyan
 color6                          #35a77c
-color14                         #83c092
+color14                         #35a77c
 
 #: white
-color7                          #5c6a72
-color15                         #d3c6aa
+color7                          #939f91
+color15                         #a6b0a0


### PR DESCRIPTION
The base 16 colors of the current Everforest scheme(s) follow the [upsteam Everforest palette](https://github.com/sainnhe/everforest) rather loosely; dark theme variants "borrow" colors from the light palette, and vice-versa. This is not the case in the original palette, which defines its [background](https://github.com/sainnhe/everforest/blob/3883583eb32776203e52afaa421b1a590b689ede/autoload/everforest.vim#L62-L91) and [foreground](https://github.com/sainnhe/everforest/blob/3883583eb32776203e52afaa421b1a590b689ede/autoload/everforest.vim#L123-L159) colors strictly.

The full rationale, as well as before/after screenshots, can be found at ewal/kitty-everforest#3.