### PR TITLE
Add GitHub themes

### DIFF
--- a/themes/GitHub_Dark.conf
+++ b/themes/GitHub_Dark.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Dark
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #c9d1d9
+background #0d1117
+selection_foreground #0d1117
+selection_background #58a6ff
+
+
+#: Cursor colors
+
+cursor #58a6ff
+
+
+#: Tab bar colors
+
+tab_bar_background #010409
+active_tab_foreground #c9d1d9
+active_tab_background #0d1117
+inactive_tab_foreground #8b949e
+inactive_tab_background #010409
+
+
+#: The basic 16 colors
+
+#: black
+color0 #484f58
+color8 #6e7681
+
+#: red
+color1 #ff7b72
+color9 #ffa198
+
+#: green
+color2 #3fb950
+color10 #56d364
+
+#: yellow
+color3 #d29922
+color11 #e3b341
+
+#: blue
+color4 #58a6ff
+color12 #79c0ff
+
+#: magenta
+color5 #bc8cff
+color13 #d2a8ff
+
+#: cyan
+color6 #39c5cf
+color14 #56d4dd
+
+#: white
+color7 #b1bac4
+color15 #ffffff

--- a/themes/GitHub_Dark_Colorblind.conf
+++ b/themes/GitHub_Dark_Colorblind.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Dark Colorblind
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #c9d1d9
+background #0d1117
+selection_foreground #0d1117
+selection_background #58a6ff
+
+
+#: Cursor colors
+
+cursor #58a6ff
+
+
+#: Tab bar colors
+
+tab_bar_background #010409
+active_tab_foreground #c9d1d9
+active_tab_background #0d1117
+inactive_tab_foreground #8b949e
+inactive_tab_background #010409
+
+
+#: The basic 16 colors
+
+#: black
+color0 #484f58
+color8 #6e7681
+
+#: red
+color1 #ec8e2c
+color9 #fdac54
+
+#: green
+color2 #58a6ff
+color10 #79c0ff
+
+#: yellow
+color3 #d29922
+color11 #e3b341
+
+#: blue
+color4 #58a6ff
+color12 #79c0ff
+
+#: magenta
+color5 #bc8cff
+color13 #d2a8ff
+
+#: cyan
+color6 #39c5cf
+color14 #56d4dd
+
+#: white
+color7 #b1bac4
+color15 #ffffff

--- a/themes/GitHub_Dark_Dimmed.conf
+++ b/themes/GitHub_Dark_Dimmed.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Dark Dimmed
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #adbac7
+background #22272e
+selection_foreground #22272e
+selection_background #539bf5
+
+
+#: Cursor colors
+
+cursor #539bf5
+
+
+#: Tab bar colors
+
+tab_bar_background #1c2128
+active_tab_foreground #adbac7
+active_tab_background #22272e
+inactive_tab_foreground #768390
+inactive_tab_background #1c2128
+
+
+#: The basic 16 colors
+
+#: black
+color0 #545d68
+color8 #636e7b
+
+#: red
+color1 #f47067
+color9 #ff938a
+
+#: green
+color2 #57ab5a
+color10 #6bc46d
+
+#: yellow
+color3 #c69026
+color11 #daaa3f
+
+#: blue
+color4 #539bf5
+color12 #6cb6ff
+
+#: magenta
+color5 #b083f0
+color13 #dcbdfb
+
+#: cyan
+color6 #39c5cf
+color14 #56d4dd
+
+#: white
+color7 #909dab
+color15 #cdd9e5

--- a/themes/GitHub_Dark_High_Contrast.conf
+++ b/themes/GitHub_Dark_High_Contrast.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Dark High Contrast
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #f0f3f6
+background #0a0c10
+selection_foreground #0a0c10
+selection_background #71b7ff
+
+
+#: Cursor colors
+
+cursor #71b7ff
+
+
+#: Tab bar colors
+
+tab_bar_background #010409
+active_tab_foreground #f0f3f6
+active_tab_background #0a0c10
+inactive_tab_foreground #f0f3f6
+inactive_tab_background #010409
+
+
+#: The basic 16 colors
+
+#: black
+color0 #7a828e
+color8 #9ea7b3
+
+#: red
+color1 #ff9492
+color9 #ffb1af
+
+#: green
+color2 #26cd4d
+color10 #4ae168
+
+#: yellow
+color3 #f0b72f
+color11 #f7c843
+
+#: blue
+color4 #71b7ff
+color12 #91cbff
+
+#: magenta
+color5 #cb9eff
+color13 #dbb7ff
+
+#: cyan
+color6 #39c5cf
+color14 #56d4dd
+
+#: white
+color7 #d9dee3
+color15 #ffffff

--- a/themes/GitHub_Light.conf
+++ b/themes/GitHub_Light.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Light
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #24292f
+background #ffffff
+selection_foreground #ffffff
+selection_background #0969da
+
+
+#: Cursor colors
+
+cursor #0969da
+
+
+#: Tab bar colors
+
+tab_bar_background #f6f8fa
+active_tab_foreground #24292f
+active_tab_background #ffffff
+inactive_tab_foreground #57606a
+inactive_tab_background #f6f8fa
+
+
+#: The basic 16 colors
+
+#: black
+color0 #24292f
+color8 #57606a
+
+#: red
+color1 #cf222e
+color9 #a40e26
+
+#: green
+color2 #116329
+color10 #1a7f37
+
+#: yellow
+color3 #4d2d00
+color11 #633c01
+
+#: blue
+color4 #0969da
+color12 #218bff
+
+#: magenta
+color5 #8250df
+color13 #a475f9
+
+#: cyan
+color6 #1b7c83
+color14 #3192aa
+
+#: white
+color7 #6e7781
+color15 #8c959f

--- a/themes/GitHub_Light_Colorblind.conf
+++ b/themes/GitHub_Light_Colorblind.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Light Colorblind
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #24292f
+background #ffffff
+selection_foreground #ffffff
+selection_background #0969da
+
+
+#: Cursor colors
+
+cursor #0969da
+
+
+#: Tab bar colors
+
+tab_bar_background #f6f8fa
+active_tab_foreground #24292f
+active_tab_background #ffffff
+inactive_tab_foreground #57606a
+inactive_tab_background #f6f8fa
+
+
+#: The basic 16 colors
+
+#: black
+color0 #24292f
+color8 #57606a
+
+#: red
+color1 #b35900
+color9 #8a4600
+
+#: green
+color2 #0550ae
+color10 #0969da
+
+#: yellow
+color3 #4d2d00
+color11 #633c01
+
+#: blue
+color4 #0969da
+color12 #218bff
+
+#: magenta
+color5 #8250df
+color13 #a475f9
+
+#: cyan
+color6 #1b7c83
+color14 #3192aa
+
+#: white
+color7 #6e7781
+color15 #8c959f

--- a/themes/GitHub_Light_High_Contrast.conf
+++ b/themes/GitHub_Light_High_Contrast.conf
@@ -1,0 +1,61 @@
+# vim:ft=kitty
+
+## name: GitHub Light High Contrast
+## author: GitHub
+## license: MIT
+
+#: The basic colors
+
+foreground #0e1116
+background #ffffff
+selection_foreground #ffffff
+selection_background #0349b4
+
+
+#: Cursor colors
+
+cursor #0349b4
+
+
+#: Tab bar colors
+
+tab_bar_background #ffffff
+active_tab_foreground #0e1116
+active_tab_background #ffffff
+inactive_tab_foreground #0e1116
+inactive_tab_background #ffffff
+
+
+#: The basic 16 colors
+
+#: black
+color0 #0e1116
+color8 #4b535d
+
+#: red
+color1 #a0111f
+color9 #86061d
+
+#: green
+color2 #024c1a
+color10 #055d20
+
+#: yellow
+color3 #3f2200
+color11 #4e2c00
+
+#: blue
+color4 #0349b4
+color12 #1168e3
+
+#: magenta
+color5 #622cbc
+color13 #844ae7
+
+#: cyan
+color6 #1b7c83
+color14 #3192aa
+
+#: white
+color7 #66707b
+color15 #88929d


### PR DESCRIPTION
Add several themes that uses the official GitHub palette, based on https://github.com/primer/github-vscode-theme.

The files are generated via https://github.com/kidonng/cherry/blob/master/deno/kitty-github-theme.ts.