### PR TITLE
Update Everforest palette

### DIFF
--- a/themes/everforest_dark_hard.conf
+++ b/themes/everforest_dark_hard.conf
@@ -6,40 +6,40 @@
 ## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
-background                      #2b3339
+background                      #272e33
 selection_foreground            #9da9a0
-selection_background            #503946
+selection_background            #4c3743
 
 cursor                          #d3c6aa
-cursor_text_color               #323c41
+cursor_text_color               #2e383c
 
 url_color                       #7fbbb3
 
 active_border_color             #a7c080
-inactive_border_color           #53605c
+inactive_border_color           #4f5b58
 bell_border_color               #e69875
 visual_bell_color               none
 
 wayland_titlebar_color          system
 macos_titlebar_color            system
 
-active_tab_background           #2b3339
+active_tab_background           #272e33
 active_tab_foreground           #d3c6aa
-inactive_tab_background         #3a454a
+inactive_tab_background         #374145
 inactive_tab_foreground         #9da9a0
-tab_bar_background              #323c41
+tab_bar_background              #2e383c
 tab_bar_margin_color            none
 
-mark1_foreground                #2b3339
+mark1_foreground                #272e33
 mark1_background                #7fbbb3
-mark2_foreground                #2b3339
+mark2_foreground                #272e33
 mark2_background                #d3c6aa
-mark3_foreground                #2b3339
+mark3_foreground                #272e33
 mark3_background                #d699b6
 
 #: black
-color0                          #374247
-color8                          #404c51
+color0                          #343f44
+color8                          #3d484d
 
 #: red
 color1                          #e67e80

--- a/themes/everforest_dark_medium.conf
+++ b/themes/everforest_dark_medium.conf
@@ -6,40 +6,40 @@
 ## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
-background                      #2f383e
+background                      #2d353b
 selection_foreground            #9da9a0
-selection_background            #573e4c
+selection_background            #543a48
 
 cursor                          #d3c6aa
-cursor_text_color               #374247
+cursor_text_color               #343f44
 
 url_color                       #7fbbb3
 
 active_border_color             #a7c080
-inactive_border_color           #596763
+inactive_border_color           #56635f
 bell_border_color               #e69875
 visual_bell_color               none
 
 wayland_titlebar_color          system
 macos_titlebar_color            system
 
-active_tab_background           #2f383e
+active_tab_background           #2d353b
 active_tab_foreground           #d3c6aa
-inactive_tab_background         #404c51
+inactive_tab_background         #3d484d
 inactive_tab_foreground         #9da9a0
-tab_bar_background              #374247
+tab_bar_background              #343f44
 tab_bar_margin_color            none
 
-mark1_foreground                #2f383e
+mark1_foreground                #2d353b
 mark1_background                #7fbbb3
-mark2_foreground                #2f383e
+mark2_foreground                #2d353b
 mark2_background                #d3c6aa
-mark3_foreground                #2f383e
+mark3_foreground                #2d353b
 mark3_background                #d699b6
 
 #: black
-color0                          #374247
-color8                          #404c51
+color0                          #343f44
+color8                          #3d484d
 
 #: red
 color1                          #e67e80

--- a/themes/everforest_dark_soft.conf
+++ b/themes/everforest_dark_soft.conf
@@ -6,40 +6,40 @@
 ## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #d3c6aa
-background                      #323d43
+background                      #333c43
 selection_foreground            #9da9a0
-selection_background            #5d4251
+selection_background            #5c3f4f
 
 cursor                          #d3c6aa
-cursor_text_color               #3c474d
+cursor_text_color               #3a464c
 
 url_color                       #7fbbb3
 
 active_border_color             #a7c080
-inactive_border_color           #5f6d67
+inactive_border_color           #5d6b66
 bell_border_color               #e69875
 visual_bell_color               none
 
 wayland_titlebar_color          system
 macos_titlebar_color            system
 
-active_tab_background           #323d43
+active_tab_background           #333c43
 active_tab_foreground           #d3c6aa
-inactive_tab_background         #465258
+inactive_tab_background         #434f55
 inactive_tab_foreground         #859289
-tab_bar_background              #3c474d
+tab_bar_background              #3a464c
 tab_bar_margin_color            none
 
-mark1_foreground                #323d43
+mark1_foreground                #333c43
 mark1_background                #7fbbb3
-mark2_foreground                #323d43
+mark2_foreground                #333c43
 mark2_background                #d3c6aa
-mark3_foreground                #323d43
+mark3_foreground                #333c43
 mark3_background                #d699b6
 
 #: black
-color0                          #374247
-color8                          #404c51
+color0                          #343f44
+color8                          #3d484d
 
 #: red
 color1                          #e67e80

--- a/themes/everforest_light_hard.conf
+++ b/themes/everforest_light_hard.conf
@@ -6,12 +6,12 @@
 ## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #5c6a72
-background                      #fff9e8
+background                      #fffbef
 selection_foreground            #829181
-selection_background            #edf0cd
+selection_background            #f0f2d4
 
 cursor                          #5c6a72
-cursor_text_color               #f7f4e0
+cursor_text_color               #f8f5e4
 
 url_color                       #3a94c5
 
@@ -23,18 +23,18 @@ visual_bell_color               none
 wayland_titlebar_color          system
 macos_titlebar_color            system
 
-active_tab_background           #fff9e8
+active_tab_background           #fffbef
 active_tab_foreground           #5c6a72
-inactive_tab_background         #f0eed9
+inactive_tab_background         #f2efdf
 inactive_tab_foreground         #939f91
-tab_bar_background              #f7f4e0
+tab_bar_background              #f8f5e4
 tab_bar_margin_color            none
 
-mark1_foreground                #fff9e8
+mark1_foreground                #fffbef
 mark1_background                #3a94c5
-mark2_foreground                #fff9e8
+mark2_foreground                #fffbef
 mark2_background                #d3c6aa
-mark3_foreground                #fff9e8
+mark3_foreground                #fffbef
 mark3_background                #df69ba
 
 #: black

--- a/themes/everforest_light_medium.conf
+++ b/themes/everforest_light_medium.conf
@@ -11,7 +11,7 @@ selection_foreground            #829181
 selection_background            #eaedc8
 
 cursor                          #5c6a72
-cursor_text_color               #f3efda
+cursor_text_color               #f4f0d9
 
 url_color                       #3a94c5
 

--- a/themes/everforest_light_soft.conf
+++ b/themes/everforest_light_soft.conf
@@ -6,12 +6,12 @@
 ## blurb: A green based color scheme designed to be warm and soft
 
 foreground                      #5c6a72
-background                      #f8f0dc
+background                      #f3ead3
 selection_foreground            #829181
-selection_background            #e6e9c4
+selection_background            #e1e4bd
 
 cursor                          #5c6a72
-cursor_text_color               #efead4
+cursor_text_color               #eae4ca
 
 url_color                       #3a94c5
 
@@ -23,18 +23,18 @@ visual_bell_color               none
 wayland_titlebar_color          system
 macos_titlebar_color            system
 
-active_tab_background           #f8f0dc
+active_tab_background           #f3ead3
 active_tab_foreground           #5c6a72
-inactive_tab_background         #e9e5cf
+inactive_tab_background         #e5dfc5
 inactive_tab_foreground         #939f91
-tab_bar_background              #efead4
+tab_bar_background              #eae4ca
 tab_bar_margin_color            none
 
-mark1_foreground                #f8f0dc
+mark1_foreground                #f3ead3
 mark1_background                #3a94c5
-mark2_foreground                #f8f0dc
+mark2_foreground                #f3ead3
 mark2_background                #d3c6aa
-mark3_foreground                #f8f0dc
+mark3_foreground                #f3ead3
 mark3_background                #df69ba
 
 #: black


### PR DESCRIPTION
Port of the [recent changes](https://github.com/sainnhe/everforest/compare/d855af543410c4047fc03798f5d58ddd07abcf2d..81041b40335344fba9aa8f100bdfc4b3dffc564d) to the Everforest palette.

Those were mainly an effort to improve the contrasts, so only background colors are affected.

---

Example of what to expect:

<details>
<summary>:framed_picture: Screenshots</summary>

<img width="550" alt="before" src="https://user-images.githubusercontent.com/3299086/217491525-6c48bbcd-d2c9-4564-9dba-63b15d4d5254.png">
<img width="527" alt="after" src="https://user-images.githubusercontent.com/3299086/217491551-fe142ebe-17aa-4cce-bd67-d5b0adaa9117.png">

</details>
