### PR TITLE
Fix Modus and Kaolin themes visibility for kittens

### DIFF
--- a/themes/Kaolin_Breeze.conf
+++ b/themes/Kaolin_Breeze.conf
@@ -27,8 +27,8 @@ inactive_tab_background #7D8468
 inactive_tab_foreground #EBE8E4
 
 # black
-color0    #383e3f
-color8    #7D8468
+color0    #EBE8E4
+color8    #C9C2BD
 
 # red
 color1    #cd5c60
@@ -55,5 +55,5 @@ color6    #48a9a9
 color14   #008b8b
 
 # white
-color7    #C9C2BD
-color15   #60696b
+color7    #7D8468
+color15   #383e3f

--- a/themes/Kaolin_Light.conf
+++ b/themes/Kaolin_Light.conf
@@ -27,8 +27,8 @@ inactive_tab_background #4b5254
 inactive_tab_foreground #EDEEEB
 
 # black
-color0   #353b3c
-color8   #4b5254
+color0   #EDEEEB
+color8   #C8CCC3
 
 # red
 color1   #e84c58
@@ -55,5 +55,5 @@ color6   #6facb3
 color14  #008b8b
 
 # white
-color7   #C8CCC3
-color15  #f5f6f5
+color7   #4b5254
+color15  #353b3c

--- a/themes/Modus_Operandi.conf
+++ b/themes/Modus_Operandi.conf
@@ -28,12 +28,12 @@ inactive_tab_background #e3e3e3
 
 # The basic 16 colors
 # black
-color0 #000000
-color8 #585858
+color0  #ffffff
+color8  #e1e1e1
 
 # red
-color1 #a60000
-color9 #972500
+color1  #a60000
+color9  #972500
 
 # green
 color2  #006800
@@ -56,5 +56,5 @@ color6  #00538b
 color14 #005a5f
 
 # white
-color7  #e1e1e1
-color15 #ffffff
+color7  #585858
+color15 #000000

--- a/themes/Modus_Operandi_Tinted.conf
+++ b/themes/Modus_Operandi_Tinted.conf
@@ -28,12 +28,12 @@ inactive_tab_background #dfd6cd
 
 # The basic 16 colors
 # black
-color0 #000000
-color8 #585858
+color0  #fbf7f0
+color8  #dfd6cd
 
 # red
-color1 #a60000
-color9 #972500
+color1  #a60000
+color9  #972500
 
 # green
 color2  #006800
@@ -56,5 +56,5 @@ color6  #00538b
 color14 #005a5f
 
 # white
-color7  #dfd6cd
-color15 #fbf7f0
+color7  #585858
+color15 #000000


### PR DESCRIPTION
Fix for https://github.com/kovidgoyal/kitty-themes/issues/68 and https://github.com/kovidgoyal/kitty/issues/6320 where `color15` wasn't visible for `select_tab` and `unicode_input` kittens.