### PR TITLE
Fix Modus and Kaolin themes visibility for kittens

### DIFF
--- a/themes/Kaolin_Breeze.conf
+++ b/themes/Kaolin_Breeze.conf
@@ -22,7 +22,7 @@ inactive_border_color   #7D8468
 
 # Tab bar colors
 active_tab_background   #383e3f
-active_tab_foreground   #EBE8E4
+active_tab_foreground   #C9C2BD
 inactive_tab_background #7D8468
 inactive_tab_foreground #EBE8E4
 

--- a/themes/Kaolin_Light.conf
+++ b/themes/Kaolin_Light.conf
@@ -22,7 +22,7 @@ inactive_border_color   #353b3c
 
 # Tab bar colors
 active_tab_background   #353b3c
-active_tab_foreground   #EDEEEB
+active_tab_foreground   #C8CCC3
 inactive_tab_background #4b5254
 inactive_tab_foreground #EDEEEB
 
@@ -56,4 +56,4 @@ color14  #008b8b
 
 # white
 color7   #C8CCC3
-color15  #f5f6f5
+color15  #4b5254

--- a/themes/Modus_Operandi.conf
+++ b/themes/Modus_Operandi.conf
@@ -22,7 +22,7 @@ inactive_border_color   #9f9f9f
 
 # Tab bar colors
 active_tab_foreground   #000000
-active_tab_background   #c5c5c5
+active_tab_background   #c4c4c4
 inactive_tab_foreground #585858
 inactive_tab_background #e3e3e3
 
@@ -56,5 +56,5 @@ color6  #00538b
 color14 #005a5f
 
 # white
-color7  #e1e1e1
-color15 #ffffff
+color7  #c4c4c4
+color15 #595959

--- a/themes/Modus_Operandi_Tinted.conf
+++ b/themes/Modus_Operandi_Tinted.conf
@@ -56,5 +56,5 @@ color6  #00538b
 color14 #005a5f
 
 # white
-color7  #dfd6cd
-color15 #fbf7f0
+color7  #c9b8b1
+color15 #585858


### PR DESCRIPTION
Proper fix for https://github.com/kovidgoyal/kitty-themes/issues/68 and https://github.com/kovidgoyal/kitty/issues/6320 where `color15` wasn't visible for `select_tab` and `unicode_input` kittens. This shouldn't break TUI applications as https://github.com/kovidgoyal/kitty-themes/pull/85 did.