### PR TITLE
Adwaita themes

### DIFF
--- a/themes/adwaita_dark.conf
+++ b/themes/adwaita_dark.conf
@@ -1,0 +1,51 @@
+# vim:ft=kitty
+
+## name: Adwaita dark
+## license: MIT
+## author: Emil Löfquist (https://github.com/ewal)
+## upstream: https://github.com/ewal/kitty-adwaita/blob/main/adwaita_dark.conf
+## blurb: Adwaita dark - based on https://github.com/Mofiqul/adwaita.nvim
+
+background                #1d1d1d
+foreground                #deddda
+
+selection_background      #303030
+selection_foreground      #c0bfbc
+
+url_color                 #1a5fb4
+
+wayland_titlebar_color    system
+macos_titlebar_color      system
+
+cursor                    #deddda
+cursor_text_color         #1d1d1d
+
+active_border_color       #4f4f4f
+inactive_border_color     #282828
+bell_border_color         #ed333b
+visual_bell_color         none
+
+active_tab_background     #242424 
+active_tab_foreground     #fcfcfc
+inactive_tab_background   #303030
+inactive_tab_foreground   #b0afac
+tab_bar_background        none
+tab_bar_margin_color      none
+
+color0                    #1d1d1d
+color1                    #ed333b
+color2                    #57e389
+color3                    #ff7800
+color4                    #62a0ea
+color5                    #9141ac
+color6                    #5bc8af
+color7                    #deddda
+
+color8                    #9a9996
+color9                    #f66151
+color10                   #8ff0a4
+color11                   #ffa348
+color12                   #99c1f1
+color13                   #dc8add
+color14                   #93ddc2
+color15                   #f6f5f4

--- a/themes/adwaita_darker.conf
+++ b/themes/adwaita_darker.conf
@@ -1,0 +1,51 @@
+# vim:ft=kitty
+
+## name: Adwaita darker
+## license: MIT
+## author: Emil Löfquist (https://github.com/ewal)
+## upstream: https://github.com/ewal/kitty-adwaita/blob/main/adwaita_darker.conf
+## blurb: Adwaita darker - based on https://github.com/Mofiqul/adwaita.nvim
+
+background                #000000
+foreground                #deddda
+
+selection_background      #1c1c1c
+selection_foreground      #c0bfbc
+
+url_color                 #1a5fb4
+
+wayland_titlebar_color    system
+macos_titlebar_color      system
+
+cursor                    #deddda
+cursor_text_color         #000000
+
+active_border_color       #1e1e1e
+inactive_border_color     #282828
+bell_border_color         #ed333b
+visual_bell_color         none
+
+active_tab_background     #101010
+active_tab_foreground     #fcfcfc
+inactive_tab_background   #1c1c1c
+inactive_tab_foreground   #b0afac
+tab_bar_background        none
+tab_bar_margin_color      none
+
+color0                    #000000
+color1                    #ed333b
+color2                    #57e389
+color3                    #ff7800
+color4                    #62a0ea
+color5                    #9141ac
+color6                    #5bc8af
+color7                    #deddda
+
+color8                    #9a9996
+color9                    #f66151
+color10                   #8ff0a4
+color11                   #ffa348
+color12                   #99c1f1
+color13                   #dc8add
+color14                   #93ddc2
+color15                   #f6f5f4

--- a/themes/adwaita_light.conf
+++ b/themes/adwaita_light.conf
@@ -1,0 +1,51 @@
+# vim:ft=kitty
+
+## name: Adwaita light
+## author: Emil Löfquist (https://github.com/ewal)
+## license: MIT
+## upstream: https://github.com/ewal/kitty-adwaita/blob/main/adwaita_light.conf
+## blurb: Adwaita light - based on https://github.com/Mofiqul/adwaita.nvim
+
+background                #fcfcfc
+foreground                #504e55
+
+selection_background      #deddda
+selection_foreground      #5e5c64
+
+url_color                 #1a5fb4
+
+wayland_titlebar_color    system
+macos_titlebar_color      system
+
+cursor                    #504e55
+cursor_text_color         #fcfcfc
+
+active_border_color       #c0bfbc
+inactive_border_color     #f6f5f4
+bell_border_color         #ed333b
+visual_bell_color         none
+
+active_tab_background     #b0afac
+active_tab_foreground     #504e55
+inactive_tab_background   #deddda
+inactive_tab_foreground   #5e5c64
+tab_bar_background        none
+tab_bar_margin_color      none
+
+color0                    #fcfcfc
+color1                    #ed333b
+color2                    #57e389
+color3                    #ff7800
+color4                    #62a0ea
+color5                    #9141ac
+color6                    #5bc8af
+color7                    #deddda
+
+color8                    #9a9996
+color9                    #f66151
+color10                   #8ff0a4
+color11                   #ffa348
+color12                   #99c1f1
+color13                   #dc8add
+color14                   #93ddc2
+color15                   #f6f5f4


### PR DESCRIPTION
Based on the neovim theme, https://github.com/Mofiqul/adwaita.nvim

![dark](https://github.com/kovidgoyal/kitty-themes/assets/676873/c3789947-ea78-4197-b41d-b6f3268f69f0)

![darker](https://github.com/kovidgoyal/kitty-themes/assets/676873/040d1227-d22b-4d97-b1a0-4f66efe7fabd)

![light](https://github.com/kovidgoyal/kitty-themes/assets/676873/f411ed35-3fb8-46c4-8e5c-e3abf9e35cd5)
