### PR TITLE
add Constant Perceptual Luminosity (dark) theme,

### DIFF
--- a/themes/Constant_Perceptual_Luminosity_dark.conf
+++ b/themes/Constant_Perceptual_Luminosity_dark.conf
@@ -1,0 +1,89 @@
+# vim:ft=kitty
+## name: Constant Perceptual Luminosity (dark)
+## author: Aaron Hall
+## license: MIT, I prefer credit (and money) to none, but I won't sue
+## upstream: none (yet)
+## blurb: ANSI term colors picked with OKHSL maximizing difference
+## in color subject to constant perceptual luminosity so that all
+## colors are readable on dark screens even against transparency
+## yet gentle on the eyes in dark environments. 
+## for colors (starting with red at 30 degrees) luminosity is .4, .6 (bright)
+## .5 for white(gray), .7 bright white (light gray)
+## 0 for black and .3 for bright black
+## For transparency I find these work ok: 
+## background_opacity 0.7
+## dynamic_background_opacity yes
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #777777
+background                      #000000
+selection_foreground #745b00
+selection_background #464646
+
+#: Cursor colors
+
+# cursor                          #cccccc
+# cursor_text_color               #111111
+
+
+#: URL underline color when hovering with mouse
+
+# url_color                       #0087bd
+
+
+#: kitty window border colors and terminal bell colors
+
+# active_border_color             #00ff00
+# inactive_border_color           #cccccc
+# bell_border_color               #ff5a00
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+# active_tab_foreground           #000
+# active_tab_background           #eee
+# inactive_tab_foreground         #444
+# inactive_tab_background         #999
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #000000
+mark1_background #3123ff
+mark2_foreground #000000
+mark2_background #745b00
+mark3_foreground #000000
+mark3_background #9b0097
+
+#: The basic 16 colors
+color0 #000000
+color1 #b10b00
+color2 #007232
+color3 #745b00
+color4 #3123ff
+color5 #9b0097
+color6 #006a78
+color7 #777777
+color8 #464646
+color9 #ff3d2b
+color10 #00ae50
+color11 #b18c00
+color12 #6786ff
+color13 #eb00e4
+color14 #00a3b7
+color15 #ababab
+


### PR DESCRIPTION
Optimized for color differences subject to constant luminosity.

blurb: 
ANSI term colors picked with OKHSL maximizing difference
in color subject to constant perceptual luminosity so that all
colors are readable on dark screens even against transparency
yet gentle on the eyes in dark environments.
for colors (starting with red at 30 degrees) luminosity is .4, .6 (bright)
.5 for white(gray), .7 bright white (light gray)
0 for black and .3 for bright black
For transparency I find these work ok:
```
background_opacity 0.7
dynamic_background_opacity yes
```