### PR TITLE
Nord: Synchronize with upstream style guidelines

### DIFF
--- a/themes/Nord.conf
+++ b/themes/Nord.conf
@@ -10,41 +10,41 @@
 # - https://gist.github.com/marcusramberg/64010234c95a93d953e8c79fdaf94192
 # - https://github.com/arcticicestudio/nord-hyper
 
-foreground            #D8DEE9
-background            #2E3440
+foreground            #d8dee9
+background            #2e3440
 selection_foreground  #000000
-selection_background  #FFFACD
-url_color             #0087BD
-cursor                #81A1C1
+selection_background  #fffacd
+url_color             #0087bd
+cursor                #81a1c1
 
 # black
-color0   #3B4252
-color8   #4C566A
+color0   #3b4252
+color8   #4c566a
 
 # red
-color1   #BF616A
-color9   #BF616A
+color1   #bf616a
+color9   #bf616a
 
 # green
-color2   #A3BE8C
-color10  #A3BE8C
+color2   #a3be8c
+color10  #a3be8c
 
 # yellow
-color3   #EBCB8B
-color11  #EBCB8B
+color3   #ebcb8b
+color11  #ebcb8b
 
 # blue
-color4  #81A1C1
-color12 #81A1C1
+color4  #81a1c1
+color12 #81a1c1
 
 # magenta
-color5   #B48EAD
-color13  #B48EAD
+color5   #b48ead
+color13  #b48ead
 
 # cyan
-color6   #88C0D0
-color14  #8FBCBB
+color6   #88c0d0
+color14  #8fbcbb
 
 # white
-color7   #E5E9F0
-color15  #ECEFF4
+color7   #e5e9f0
+color15  #eceff4

--- a/themes/Nord.conf
+++ b/themes/Nord.conf
@@ -1,50 +1,73 @@
 # vim:ft=kitty
 ## name: Nord
-## author: Connor Holyday
-## license: MIT
-## upstream: https://raw.githubusercontent.com/connorholyday/nord-kitty/master/nord.conf
-## blurb: An arctic, north-bluish clean and elegant Kitty theme.
+## author: Eric N. Vander Weele
+## upstream: https://www.nordtheme.com/
+## blurb: Nord theme utilizing the full Frost and Aurora palette.
 
-# Nord Colorscheme for Kitty
-# Based on:
-# - https://gist.github.com/marcusramberg/64010234c95a93d953e8c79fdaf94192
-# - https://github.com/arcticicestudio/nord-hyper
+# Basic colors
+foreground           #d8dee9
+background           #2e3440
+selection_foreground #d8dee9
+selection_background #434c5e
 
-foreground            #d8dee9
-background            #2e3440
-selection_foreground  #000000
-selection_background  #fffacd
-url_color             #0087bd
-cursor                #81a1c1
+# Cursor colors
+cursor            #d8dee9
+cursor_text_color #3b4252
 
+# URL underline color when hovering with mouse
+url_color #0087bd
+
+# Window border colors and terminal bell colors
+active_border_color   #81a1c1
+inactive_border_color #4c566a
+bell_border_color     #88c0d0
+visual_bell_color     none
+
+# Tab bar colors
+active_tab_foreground   #3b4252
+active_tab_background   #88c0d0
+inactive_tab_foreground #e5e9f0
+inactive_tab_background #4c566a
+tab_bar_background      #3b4252
+tab_bar_margin_color    none
+
+# Mark colors (marked text in the terminal)
+mark1_foreground #3b4252
+mark1_background #88c0d0
+mark2_foreground #3b4252
+mark2_background #bf616a
+mark3_foreground #3b4252
+mark3_background #ebcb8b
+
+# The basic 16 colors
 # black
-color0   #3b4252
-color8   #4c566a
+color0 #3b4252
+color8 #4c566a
 
 # red
-color1   #bf616a
-color9   #bf616a
+color1 #bf616a
+color9 #bf616a
 
 # green
-color2   #a3be8c
-color10  #a3be8c
+color2  #a3be8c
+color10 #a3be8c
 
 # yellow
-color3   #ebcb8b
-color11  #ebcb8b
+color3  #ebcb8b
+color11 #d08770
 
 # blue
 color4  #81a1c1
-color12 #81a1c1
+color12 #5e81ac
 
 # magenta
-color5   #b48ead
-color13  #b48ead
+color5  #b48ead
+color13 #b48ead
 
 # cyan
-color6   #88c0d0
-color14  #8fbcbb
+color6  #88c0d0
+color14 #8fbcbb
 
 # white
-color7   #e5e9f0
-color15  #eceff4
+color7  #e5e9f0
+color15 #eceff4


### PR DESCRIPTION
Synchronize with the official style guidelines outlined in
https://www.nordtheme.com/docs/colors-and-palettes.

Notable changes are:

* cursor: Use nord4 as prescribed in the style guidelines.
* color11: Use nord12 to utilize all colors in the Aurora palette.
* color12: Use nord10 to utilize all colors in the Frost palette.

Window, Tab, and Marker colors are provided in adherence to the style
guidelines where reasonably applicable.

---

I created two commits to aid in reviewing this PR. The first commit normalizes the color values to lowercase, and the second introduces the actual changes. There is some churn to align the file with `template.conf`. If the rearranging of sections is undesirable, please let me know and I rework the PR to make the diff more amenable for review.