### PR TITLE
OS title bar colors?

### DIFF
--- a/themes/VSCode_Dark.conf
+++ b/themes/VSCode_Dark.conf
@@ -10,6 +10,10 @@ background              #1e1e1e
 selection_foreground    #cccccc
 selection_background    #264f78
 
+# OS Window titlebar colors
+wayland_titlebar_color #1e1e1e
+macos_titlebar_color   #1e1e1e
+
 # Cursor colors
 cursor                  #ffffff
 cursor_text_color       #1e1e1e


### PR DESCRIPTION
I've only made one change in this PR, to the theme I'm currently using. I'm wondering if it'd be worthwhile to implement this change across the rest of the themes to make the title bar match the background color by default?

Before:

<img width="923" alt="image" src="https://github.com/kovidgoyal/kitty-themes/assets/15133041/6e4c4dcd-e3f6-461e-9492-1f99c4214cef">

After:

<img width="923" alt="image" src="https://github.com/kovidgoyal/kitty-themes/assets/15133041/e8f42726-d077-46c6-b0ae-c484b7864468">

