### PR TITLE
Add One Dark Pro Theme

### DIFF
--- a/themes/OneDark-Pro.conf
+++ b/themes/OneDark-Pro.conf
@@ -1,0 +1,62 @@
+# vim:ft=kitty
+
+## name:     OneDark-Pro
+## author:   VictorPL (https://github.com/VictorPLopes)
+## license:  MIT
+## upstream: https://github.com/VictorPLopes/OneDark-Pro-Kitty-Terminal/blob/main/kitty-themes/OneDark-Pro.conf
+## blurb:    Kitty theme inspired by Binaryify's One Dark Pro theme for Visual Studio Code.
+
+# Colors
+
+# The basic colors
+foreground              #ABB2BF
+background              #282C34
+selection_foreground    #282C34
+selection_background    #ABB2BF
+
+# Cursor colors
+cursor                  #ABB2BF
+cursor_text_color       #282C34
+
+# URL underline color when hovering with mouse
+url_color               #ABB2BF
+
+# Tab bar colors
+active_tab_foreground   #3F4451
+active_tab_background   #D7DAE0
+inactive_tab_foreground #ABB2BF
+inactive_tab_background #282C34
+
+# The 16 terminal colors
+
+# black
+color0 #3F4451
+color8 #4F5666
+
+# red
+color1 #E06C75
+color9 #BE5046
+
+# green
+color2  #98C379
+color10 #A5E075
+
+# yellow
+color3  #D19A66
+color11 #E5C07B
+
+# blue
+color4  #61AFEF
+color12 #4DC4FF
+
+# purple
+color5  #C678DD
+color13 #DE73FF
+
+# cyan
+color6  #56B6C2
+color14 #4CD1E0
+
+# white
+color7  #D7DAE0
+color15 #E6E6E6


### PR DESCRIPTION
Add [my One Dark Pro Theme](https://github.com/VictorPLopes/OneDark-Pro-Kitty-Terminal), inspired by Binaryify's One Dark Pro theme for Visual Studio Code.
![One Dark Pro](https://github.com/VictorPLopes/OneDark-Pro-Kitty-Terminal/raw/main/screenshots/one-dark-pro-kubuntu.png)