### PR TITLE
Remove URLs from theme name and author for spaceduck

### DIFF
--- a/themes/spaceduck.conf
+++ b/themes/spaceduck.conf
@@ -1,7 +1,9 @@
 # vim:ft=kitty
 
-## name:     spaceduck (https://github.com/pineapplegiant/spaceduck)
-## author:   Guillermo Rodriguez (https://github.com/pineapplegiant)
+#: Repository: https://github.com/pineapplegiant/spaceduck
+
+## name:     spaceduck
+## author:   Guillermo Rodriguez
 ## license:  MIT
 
 ## upstream: https://github.com/foofrog/kitty-themes/blob/master/themes/spaceduck.conf


### PR DESCRIPTION
# Changes

Unnecessary URLs have been removed from the theme and author metadata fields. This helps prevent theme name from displaying with the URL in the themes list when using the command `kitty +kitten themes`.