### PR TITLE
added (duotone) Base2Tone dark themes

### DIFF
--- a/themes/base2tone-cave-dark.conf
+++ b/themes/base2tone-cave-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Cave Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-cave-dark.conf
+## blurb: Duotone theme | cool cave red - yellow ochre
+
+
+#: The basic colors
+
+foreground #9f999b
+background #222021
+selection_foreground #9f999b
+selection_background #2f2d2e
+
+
+#: Cursor colors
+
+cursor #996e00
+cursor_text_color #222021
+
+
+#: URL underline color when hovering with mouse
+
+url_color #f0a8c1
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #565254
+inactive_border_color #222021
+bell_border_color #ad1f51
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2f2d2e
+macos_titlebar_color #2f2d2e
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfaf9
+active_tab_background #222021
+inactive_tab_foreground #aeaca7
+inactive_tab_background #2f2d2e
+tab_bar_background #2f2d2e
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #222021
+mark1_background #875e6d
+mark2_foreground #222021
+mark2_background #8b8984
+mark3_foreground #222021
+mark3_background #aa7c09
+
+
+#: The basic 16 colors
+
+#: black
+color0 #222021
+color8 #635f60
+
+#: red
+color1 #936c7a
+color9 #ddaf3c
+
+#: green
+color2 #cca133
+color10 #2f2d2e
+
+#: yellow
+color3 #ffcc4d
+color11 #565254
+
+#: blue
+color4 #9c818b
+color12 #706b6d
+
+#: magenta
+color5 #cca133
+color13 #f0a8c1
+
+#: cyan
+color6 #d27998
+color14 #c39622
+
+#: white
+color7 #9f999b
+color15 #ffebf2

--- a/themes/base2tone-desert-dark.conf
+++ b/themes/base2tone-desert-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Desert Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-desert-dark.conf
+## blurb: Duotone theme | brown umber - desert orange
+
+
+#: The basic colors
+
+foreground #ada594
+background #292724
+selection_foreground #ada594
+selection_background #3d3a34
+
+
+#: Cursor colors
+
+cursor #bc672f
+cursor_text_color #292724
+
+
+#: URL underline color when hovering with mouse
+
+url_color #ddcba6
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #615c51
+inactive_border_color #292724
+bell_border_color #5c523d
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #3d3a34
+macos_titlebar_color #3d3a34
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfaf9
+active_tab_background #292724
+inactive_tab_foreground #b9b1ac
+inactive_tab_background #3d3a34
+tab_bar_background #3d3a34
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #292724
+mark1_background #6e6045
+mark2_foreground #292724
+mark2_background #978d87
+mark3_foreground #292724
+mark3_background #d37231
+
+
+#: The basic 16 colors
+
+#: black
+color0 #292724
+color8 #7e7767
+
+#: red
+color1 #816f4b
+color9 #f29d63
+
+#: green
+color2 #ec9255
+color10 #3d3a34
+
+#: yellow
+color3 #ffb380
+color11 #615c51
+
+#: blue
+color4 #957e50
+color12 #908774
+
+#: magenta
+color5 #ec9255
+color13 #ddcba6
+
+#: cyan
+color6 #ac8e53
+color14 #e58748
+
+#: white
+color7 #ada594
+color15 #f2ead9

--- a/themes/base2tone-drawbridge-dark.conf
+++ b/themes/base2tone-drawbridge-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Drawbridge Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-drawbridge-dark.conf
+## blurb: Duotone theme | bright blue - bright turquoise
+
+
+#: The basic colors
+
+foreground #9094a7
+background #1b1f32
+selection_foreground #9094a7
+selection_background #252a41
+
+
+#: Cursor colors
+
+cursor #289dbd
+cursor_text_color #1b1f32
+
+
+#: URL underline color when hovering with mouse
+
+url_color #c3cdfe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #444b6f
+inactive_border_color #1b1f32
+bell_border_color #4961da
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #252a41
+macos_titlebar_color #252a41
+
+
+#: Tab bar colors
+
+active_tab_foreground #f9fbfb
+active_tab_background #1b1f32
+inactive_tab_foreground #a6aeb0
+inactive_tab_background #252a41
+tab_bar_background #252a41
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #1b1f32
+mark1_background #516aec
+mark2_foreground #1b1f32
+mark2_background #818b8d
+mark3_foreground #1b1f32
+mark3_background #33abcc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1b1f32
+color8 #51587b
+
+#: red
+color1 #627af4
+color9 #75d5f0
+
+#: green
+color2 #67c9e4
+color10 #252a41
+
+#: yellow
+color3 #99e9ff
+color11 #444b6f
+
+#: blue
+color4 #7289fd
+color12 #5e6587
+
+#: magenta
+color5 #67c9e4
+color13 #c3cdfe
+
+#: cyan
+color6 #8b9efd
+color14 #5cbcd6
+
+#: white
+color7 #9094a7
+color15 #e1e6ff

--- a/themes/base2tone-earth-dark.conf
+++ b/themes/base2tone-earth-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Earth Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-earth-dark.conf
+## blurb: Duotone theme | brown earth - brown ochre/khaki
+
+
+#: The basic colors
+
+foreground #b5a9a1
+background #322d29
+selection_foreground #b5a9a1
+selection_background #3f3a37
+
+
+#: Cursor colors
+
+cursor #9c8349
+cursor_text_color #322d29
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dfb99f
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #5b534d
+inactive_border_color #322d29
+bell_border_color #6f5849
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #3f3a37
+macos_titlebar_color #3f3a37
+
+
+#: Tab bar colors
+
+active_tab_foreground #f2efe8
+active_tab_background #322d29
+inactive_tab_foreground #aaa392
+inactive_tab_background #3f3a37
+tab_bar_background #3f3a37
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #322d29
+mark1_background #786254
+mark2_foreground #322d29
+mark2_background #88806d
+mark3_foreground #322d29
+mark3_background #b3944d
+
+
+#: The basic 16 colors
+
+#: black
+color0 #322d29
+color8 #6a5f58
+
+#: red
+color1 #816d5f
+color9 #e6b84d
+
+#: green
+color2 #d9b154
+color10 #3f3a37
+
+#: yellow
+color3 #fcc440
+color11 #5b534d
+
+#: blue
+color4 #88786d
+color12 #796b63
+
+#: magenta
+color5 #d9b154
+color13 #dfb99f
+
+#: cyan
+color6 #967e6e
+color14 #cda956
+
+#: white
+color7 #b5a9a1
+color15 #fff3eb

--- a/themes/base2tone-evening-dark.conf
+++ b/themes/base2tone-evening-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Evening Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-evening-dark.conf
+## blurb: Default duotone theme | purple - orange
+
+
+#: The basic colors
+
+foreground #a4a1b5
+background #2a2734
+selection_foreground #a4a1b5
+selection_background #363342
+
+
+#: Cursor colors
+
+cursor #b37537
+cursor_text_color #2a2734
+
+
+#: URL underline color when hovering with mouse
+
+url_color #d9d2fe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #545167
+inactive_border_color #2a2734
+bell_border_color #6a51e6
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #363342
+macos_titlebar_color #363342
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfaf9
+active_tab_background #2a2734
+inactive_tab_foreground #b2aba4
+inactive_tab_background #363342
+tab_bar_background #363342
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #2a2734
+mark1_background #7a63ee
+mark2_foreground #2a2734
+mark2_background #90877f
+mark3_foreground #2a2734
+mark3_background #cb823a
+
+
+#: The basic 16 colors
+
+#: black
+color0 #2a2734
+color8 #6c6783
+
+#: red
+color1 #8a75f5
+color9 #ffb870
+
+#: green
+color2 #ffad5c
+color10 #363342
+
+#: yellow
+color3 #ffcc99
+color11 #545167
+
+#: blue
+color4 #9a86fd
+color12 #787391
+
+#: magenta
+color5 #ffad5c
+color13 #d9d2fe
+
+#: cyan
+color6 #afa0fe
+color14 #ffa142
+
+#: white
+color7 #a4a1b5
+color15 #eeebff

--- a/themes/base2tone-field-dark.conf
+++ b/themes/base2tone-field-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Field Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-field-dark.conf
+## blurb: duotone theme | teal/turqoise - bright field green
+
+
+#: The basic colors
+
+foreground #8ea4a0
+background #18201e
+selection_foreground #8ea4a0
+selection_background #242e2c
+
+
+#: Cursor colors
+
+cursor #00943e
+cursor_text_color #18201e
+
+
+#: URL underline color when hovering with mouse
+
+url_color #88f2e0
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #42524f
+inactive_border_color #18201e
+bell_border_color #037764
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #242e2c
+macos_titlebar_color #242e2c
+
+
+#: Tab bar colors
+
+active_tab_foreground #f9fbfa
+active_tab_background #18201e
+inactive_tab_foreground #9daaa2
+inactive_tab_background #242e2c
+tab_bar_background #242e2c
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #18201e
+mark1_background #089b83
+mark2_foreground #18201e
+mark2_background #78877e
+mark3_foreground #18201e
+mark3_background #0eaa4f
+
+
+#: The basic 16 colors
+
+#: black
+color0 #18201e
+color8 #5a6d6a
+
+#: red
+color1 #0fbda0
+color9 #55ec94
+
+#: green
+color2 #3be381
+color10 #242e2c
+
+#: yellow
+color3 #85ffb8
+color11 #42524f
+
+#: blue
+color4 #25d0b4
+color12 #667a77
+
+#: magenta
+color5 #3be381
+color13 #88f2e0
+
+#: cyan
+color6 #40ddc3
+color14 #25d46e
+
+#: white
+color7 #8ea4a0
+color15 #a8fff1

--- a/themes/base2tone-forest-dark.conf
+++ b/themes/base2tone-forest-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Forest Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-forest-dark.conf
+## blurb: duotone theme | muted forest green - light yellow-green
+
+
+#: The basic colors
+
+foreground #a1b5a1
+background #2a2d2a
+selection_foreground #a1b5a1
+selection_background #353b35
+
+
+#: Cursor colors
+
+cursor #656b47
+cursor_text_color #2a2d2a
+
+
+#: URL underline color when hovering with mouse
+
+url_color #c8e4c8
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #485148
+inactive_border_color #2a2d2a
+bell_border_color #435643
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #353b35
+macos_titlebar_color #353b35
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfbf8
+active_tab_background #2a2d2a
+inactive_tab_foreground #b2b5a1
+inactive_tab_background #353b35
+tab_bar_background #353b35
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #2a2d2a
+mark1_background #4f634f
+mark2_foreground #2a2d2a
+mark2_background #90947a
+mark3_foreground #2a2d2a
+mark3_background #818b4b
+
+
+#: The basic 16 colors
+
+#: black
+color0 #2a2d2a
+color8 #535f53
+
+#: red
+color1 #5c705c
+color9 #cbe25a
+
+#: green
+color2 #bfd454
+color10 #353b35
+
+#: yellow
+color3 #e5fb79
+color11 #485148
+
+#: blue
+color4 #687d68
+color12 #5e6e5e
+
+#: magenta
+color5 #bfd454
+color13 #c8e4c8
+
+#: cyan
+color6 #8fae8f
+color14 #b1c44f
+
+#: white
+color7 #a1b5a1
+color15 #f0fff0

--- a/themes/base2tone-garden-dark.conf
+++ b/themes/base2tone-garden-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Garden Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-garden-dark.conf
+## blurb: duotone theme | lime garden green - muted orange
+
+
+#: The basic colors
+
+foreground #969c96
+background #1e1f1e
+selection_foreground #969c96
+selection_background #2b2c2a
+
+
+#: Cursor colors
+
+cursor #bd5d0f
+cursor_text_color #1e1f1e
+
+
+#: URL underline color when hovering with mouse
+
+url_color #b7e3b5
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #505350
+inactive_border_color #1e1f1e
+bell_border_color #1c8217
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2b2c2a
+macos_titlebar_color #2b2c2a
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfaf8
+active_tab_background #1e1f1e
+inactive_tab_foreground #b7aa9f
+inactive_tab_background #2b2c2a
+tab_bar_background #2b2c2a
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #1e1f1e
+mark1_background #25931f
+mark2_foreground #1e1f1e
+mark2_background #978678
+mark3_foreground #1e1f1e
+mark3_background #c96a1d
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1e1f1e
+color8 #5d605c
+
+#: red
+color1 #3fac39
+color9 #dba070
+
+#: green
+color2 #db9257
+color10 #2b2c2a
+
+#: yellow
+color3 #e0cab8
+color11 #505350
+
+#: blue
+color4 #4cb946
+color12 #696d69
+
+#: magenta
+color5 #db9257
+color13 #b7e3b5
+
+#: cyan
+color6 #6bcc66
+color14 #dd843c
+
+#: white
+color7 #969c96
+color15 #dcf0db

--- a/themes/base2tone-heath-dark.conf
+++ b/themes/base2tone-heath-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Heath Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-heath-dark.conf
+## blurb: duotone theme | violet heath magenta - siena brown orange
+
+
+#: The basic colors
+
+foreground #9e999f
+background #222022
+selection_foreground #9e999f
+selection_background #2f2d2f
+
+
+#: Cursor colors
+
+cursor #995900
+cursor_text_color #222022
+
+
+#: URL underline color when hovering with mouse
+
+url_color #eaa8f0
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #575158
+inactive_border_color #222022
+bell_border_color #a21fad
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2f2d2f
+macos_titlebar_color #2f2d2f
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbfaf9
+active_tab_background #222022
+inactive_tab_foreground #aeaba7
+inactive_tab_background #2f2d2f
+tab_bar_background #2f2d2f
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #222022
+mark1_background #845e87
+mark2_foreground #222022
+mark2_background #8b8884
+mark3_foreground #222022
+mark3_background #aa6709
+
+
+#: The basic 16 colors
+
+#: black
+color0 #222022
+color8 #635f63
+
+#: red
+color1 #8f6c93
+color9 #d9b98c
+
+#: green
+color2 #cc8c33
+color10 #2f2d2f
+
+#: yellow
+color3 #ffd599
+color11 #575158
+
+#: blue
+color4 #9a819c
+color12 #6f6b70
+
+#: magenta
+color5 #cc8c33
+color13 #eaa8f0
+
+#: cyan
+color6 #cb79d2
+color14 #c38022
+
+#: white
+color7 #9e999f
+color15 #fdebff

--- a/themes/base2tone-lake-dark.conf
+++ b/themes/base2tone-lake-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Lake Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-lake-dark.conf
+## blurb: duotone theme | lime lake green - muted orange
+
+
+#: The basic colors
+
+foreground #7ba8b7
+background #192d34
+selection_foreground #7ba8b7
+selection_background #223c44
+
+
+#: Cursor colors
+
+cursor #84740b
+cursor_text_color #192d34
+
+
+#: URL underline color when hovering with mouse
+
+url_color #a5d8e9
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #335966
+inactive_border_color #192d34
+bell_border_color #2f7289
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #223c44
+macos_titlebar_color #223c44
+
+
+#: Tab bar colors
+
+active_tab_foreground #fafaf9
+active_tab_background #192d34
+inactive_tab_foreground #b1afa5
+inactive_tab_background #223c44
+tab_bar_background #223c44
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #192d34
+mark1_background #36829b
+mark2_foreground #192d34
+mark2_background #8d8c81
+mark3_foreground #192d34
+mark3_background #978611
+
+
+#: The basic 16 colors
+
+#: black
+color0 #192d34
+color8 #3d6876
+
+#: red
+color1 #3e91ac
+color9 #d6c65c
+
+#: green
+color2 #cbbb4d
+color10 #223c44
+
+#: yellow
+color3 #ffeb66
+color11 #335966
+
+#: blue
+color4 #499fbc
+color12 #467686
+
+#: magenta
+color5 #cbbb4d
+color13 #a5d8e9
+
+#: cyan
+color6 #62b1cb
+color14 #c4b031
+
+#: white
+color7 #7ba8b7
+color15 #e1f7ff

--- a/themes/base2tone-lavender-dark.conf
+++ b/themes/base2tone-lavender-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Lavender Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-lavender-dark.conf
+## blurb: duotone theme | blue lavender violet - magenta
+
+
+#: The basic colors
+
+foreground #9992b0
+background #201d2a
+selection_foreground #9992b0
+selection_background #2c2839
+
+
+#: Cursor colors
+
+cursor #b042ff
+cursor_text_color #201d2a
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dcd2fe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #4b455f
+inactive_border_color #201d2a
+bell_border_color #7451e6
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2c2839
+macos_titlebar_color #2c2839
+
+
+#: Tab bar colors
+
+active_tab_foreground #faf8fc
+active_tab_background #201d2a
+inactive_tab_foreground #b2a4bc
+inactive_tab_background #2c2839
+tab_bar_background #2c2839
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #201d2a
+mark1_background #8363ee
+mark2_foreground #201d2a
+mark2_background #8e8198
+mark3_foreground #201d2a
+mark3_background #b957ff
+
+
+#: The basic 16 colors
+
+#: black
+color0 #201d2a
+color8 #625a7c
+
+#: red
+color1 #9375f5
+color9 #dba8ff
+
+#: green
+color2 #d294ff
+color10 #2c2839
+
+#: yellow
+color3 #ecd1ff
+color11 #4b455f
+
+#: blue
+color4 #a286fd
+color12 #6e658b
+
+#: magenta
+color5 #d294ff
+color13 #dcd2fe
+
+#: cyan
+color6 #b5a0fe
+color14 #ca80ff
+
+#: white
+color7 #9992b0
+color15 #efebff

--- a/themes/base2tone-mall-dark.conf
+++ b/themes/base2tone-mall-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Mall Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-mall-dark.conf
+## blurb: duotone theme | blue violet - light sky blue
+
+
+#: The basic colors
+
+foreground #97959d
+background #1e1e1f
+selection_foreground #97959d
+selection_background #2b2b2c
+
+
+#: Cursor colors
+
+cursor #3692e2
+cursor_text_color #1e1e1f
+
+
+#: URL underline color when hovering with mouse
+
+url_color #e5dbff
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #515053
+inactive_border_color #1e1e1f
+bell_border_color #855ee8
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2b2b2c
+macos_titlebar_color #2b2b2c
+
+
+#: Tab bar colors
+
+active_tab_foreground #f8fafc
+active_tab_background #1e1e1f
+inactive_tab_foreground #a2abb3
+inactive_tab_background #2b2b2c
+tab_bar_background #2b2b2c
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #1e1e1f
+mark1_background #936df3
+mark2_foreground #1e1e1f
+mark2_background #7e8891
+mark3_foreground #1e1e1f
+mark3_background #479eeb
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1e1e1f
+color8 #5e5c60
+
+#: red
+color1 #a17efc
+color9 #8ac8ff
+
+#: green
+color2 #75bfff
+color10 #2b2b2c
+
+#: yellow
+color3 #b3dbff
+color11 #515053
+
+#: blue
+color4 #b294ff
+color12 #6a686e
+
+#: magenta
+color5 #75bfff
+color13 #e5dbff
+
+#: cyan
+color6 #c5adff
+color14 #69b5f7
+
+#: white
+color7 #97959d
+color15 #f4f0ff

--- a/themes/base2tone-meadow-dark.conf
+++ b/themes/base2tone-meadow-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Meadow Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-meadow-dark.conf
+## blurb: duotone theme | slate blue - light lime green
+
+
+#: The basic colors
+
+foreground #7b9eb7
+background #192834
+selection_foreground #7b9eb7
+selection_background #223644
+
+
+#: Cursor colors
+
+cursor #4d8217
+cursor_text_color #192834
+
+
+#: URL underline color when hovering with mouse
+
+url_color #afddfe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #335166
+inactive_border_color #192834
+bell_border_color #1b6498
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #223644
+macos_titlebar_color #223644
+
+
+#: Tab bar colors
+
+active_tab_foreground #fafbf9
+active_tab_background #192834
+inactive_tab_foreground #abb1a5
+inactive_tab_background #223644
+tab_bar_background #223644
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #192834
+mark1_background #2172ab
+mark2_foreground #192834
+mark2_background #878e80
+mark3_foreground #192834
+mark3_background #59931f
+
+
+#: The basic 16 colors
+
+#: black
+color0 #192834
+color8 #3d5e76
+
+#: red
+color1 #277fbe
+color9 #8cdd3c
+
+#: green
+color2 #80bf40
+color10 #223644
+
+#: yellow
+color3 #a6f655
+color11 #335166
+
+#: blue
+color4 #4299d7
+color12 #466b86
+
+#: magenta
+color5 #80bf40
+color13 #afddfe
+
+#: cyan
+color6 #47adf5
+color14 #73b234
+
+#: white
+color7 #7b9eb7
+color15 #d1ecff

--- a/themes/base2tone-morning-dark.conf
+++ b/themes/base2tone-morning-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Morning Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-morning-dark.conf
+## blurb: duotone theme | warm blue - yellow brown ochre
+
+
+#: The basic colors
+
+foreground #8d95a5
+background #232834
+selection_foreground #8d95a5
+selection_background #31363f
+
+
+#: Cursor colors
+
+cursor #2d2006
+cursor_text_color #232834
+
+
+#: URL underline color when hovering with mouse
+
+url_color #b7c9eb
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #4f5664
+inactive_border_color #232834
+bell_border_color #063289
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #31363f
+macos_titlebar_color #31363f
+
+
+#: Tab bar colors
+
+active_tab_foreground #faf8f5
+active_tab_background #232834
+inactive_tab_foreground #9c927c
+inactive_tab_background #31363f
+tab_bar_background #31363f
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #232834
+mark1_background #0b3c9d
+mark2_foreground #232834
+mark2_background #69604f
+mark3_foreground #232834
+mark3_background #594212
+
+
+#: The basic 16 colors
+
+#: black
+color0 #232834
+color8 #656e81
+
+#: red
+color1 #1659df
+color9 #c6b28b
+
+#: green
+color2 #b29762
+color10 #31363f
+
+#: yellow
+color3 #e5ddcd
+color11 #4f5664
+
+#: blue
+color4 #3d75e6
+color12 #707a8f
+
+#: magenta
+color5 #b29762
+color13 #b7c9eb
+
+#: cyan
+color6 #728fcb
+color14 #9a7c42
+
+#: white
+color7 #8d95a5
+color15 #dee6f7

--- a/themes/base2tone-motel-dark.conf
+++ b/themes/base2tone-motel-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Motel Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-motel-dark.conf
+## blurb: duotone theme | rosy brown - coral salmon orange
+
+
+#: The basic colors
+
+foreground #a5979a
+background #242323
+selection_foreground #a5979a
+selection_background #373434
+
+
+#: Cursor colors
+
+cursor #e24f32
+cursor_text_color #242323
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dec9cc
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #5a5354
+inactive_border_color #242323
+bell_border_color #674c50
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #373434
+macos_titlebar_color #373434
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbf9f9
+active_tab_background #242323
+inactive_tab_foreground #b9aeac
+inactive_tab_background #373434
+tab_bar_background #373434
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #242323
+mark1_background #7d5e63
+mark2_foreground #242323
+mark2_background #978a87
+mark3_foreground #242323
+mark3_background #ea5f43
+
+
+#: The basic 16 colors
+
+#: black
+color0 #242323
+color8 #766b6c
+
+#: red
+color1 #956f76
+color9 #ffa28f
+
+#: green
+color2 #f8917c
+color10 #373434
+
+#: yellow
+color3 #ffc8bd
+color11 #5a5354
+
+#: blue
+color4 #a7868b
+color12 #86797b
+
+#: magenta
+color5 #f8917c
+color13 #dec9cc
+
+#: cyan
+color6 #b89da2
+color14 #f77c64
+
+#: white
+color7 #a5979a
+color15 #f0dbdf

--- a/themes/base2tone-pool-dark.conf
+++ b/themes/base2tone-pool-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Pool Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-pool-dark.conf
+## blurb: duotone theme | violet - salmon orange
+
+
+#: The basic colors
+
+foreground #9a90a7
+background #2a2433
+selection_foreground #9a90a7
+selection_background #372f42
+
+
+#: Cursor colors
+
+cursor #cf504a
+cursor_text_color #2a2433
+
+
+#: URL underline color when hovering with mouse
+
+url_color #e4d2fe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #574b68
+inactive_border_color #2a2433
+bell_border_color #8f51e6
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #372f42
+macos_titlebar_color #372f42
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbf9f9
+active_tab_background #2a2433
+inactive_tab_foreground #b0a6a6
+inactive_tab_background #372f42
+tab_bar_background #372f42
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #2a2433
+mark1_background #9d63ee
+mark2_foreground #2a2433
+mark2_background #8d8281
+mark3_foreground #2a2433
+mark3_background #d95f59
+
+
+#: The basic 16 colors
+
+#: black
+color0 #2a2433
+color8 #635775
+
+#: red
+color1 #aa75f5
+color9 #fc8983
+
+#: green
+color2 #f87972
+color10 #372f42
+
+#: yellow
+color3 #ffb6b3
+color11 #574b68
+
+#: blue
+color4 #b886fd
+color12 #706383
+
+#: magenta
+color5 #f87972
+color13 #e4d2fe
+
+#: cyan
+color6 #c7a0fe
+color14 #f36f68
+
+#: white
+color7 #9a90a7
+color15 #f3ebff

--- a/themes/base2tone-porch-dark.conf
+++ b/themes/base2tone-porch-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Porch Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-porch-dark.conf
+## blurb: duotone theme | muted violet - light orange
+
+
+#: The basic colors
+
+foreground #9f95a3
+background #221e24
+selection_foreground #9f95a3
+selection_background #302a32
+
+
+#: Cursor colors
+
+cursor #c46731
+cursor_text_color #221e24
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dfcbe6
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #574e5a
+inactive_border_color #221e24
+bell_border_color #674573
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #302a32
+macos_titlebar_color #302a32
+
+
+#: Tab bar colors
+
+active_tab_foreground #fcf9f8
+active_tab_background #221e24
+inactive_tab_foreground #b3a9a2
+inactive_tab_background #302a32
+tab_bar_background #302a32
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #221e24
+mark1_background #7e548c
+mark2_foreground #221e24
+mark2_background #91857e
+mark3_foreground #221e24
+mark3_background #d97136
+
+
+#: The basic 16 colors
+
+#: black
+color0 #221e24
+color8 #645a68
+
+#: red
+color1 #9466a3
+color9 #f8aa7c
+
+#: green
+color2 #f39b68
+color10 #302a32
+
+#: yellow
+color3 #ffc29e
+color11 #574e5a
+
+#: blue
+color4 #a77cb6
+color12 #716774
+
+#: magenta
+color5 #f39b68
+color13 #dfcbe6
+
+#: cyan
+color6 #ba95c6
+color14 #ec8d55
+
+#: white
+color7 #9f95a3
+color15 #f2e3f7

--- a/themes/base2tone-sea-dark.conf
+++ b/themes/base2tone-sea-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Sea Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-sea-dark.conf
+## blurb: duotone theme | slate sea blue - medium sea green
+
+
+#: The basic colors
+
+foreground #a1aab5
+background #1d262f
+selection_foreground #a1aab5
+selection_background #27323f
+
+
+#: Cursor colors
+
+cursor #067953
+cursor_text_color #1d262f
+
+
+#: URL underline color when hovering with mouse
+
+url_color #afd4fe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #405368
+inactive_border_color #1d262f
+bell_border_color #004a9e
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #27323f
+macos_titlebar_color #27323f
+
+
+#: Tab bar colors
+
+active_tab_foreground #f9fbfa
+active_tab_background #1d262f
+inactive_tab_foreground #a6b0ad
+inactive_tab_background #27323f
+tab_bar_background #27323f
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #1d262f
+mark1_background #1757a1
+mark2_foreground #1d262f
+mark2_background #818d89
+mark3_foreground #1d262f
+mark3_background #088c60
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1d262f
+color8 #4a5f78
+
+#: red
+color1 #34659d
+color9 #14e19d
+
+#: green
+color2 #0fc78a
+color10 #27323f
+
+#: yellow
+color3 #47ebb4
+color11 #405368
+
+#: blue
+color4 #57718e
+color12 #738191
+
+#: magenta
+color5 #0fc78a
+color13 #afd4fe
+
+#: cyan
+color6 #6e9bcf
+color14 #0db57d
+
+#: white
+color7 #a1aab5
+color15 #ebf4ff

--- a/themes/base2tone-space-dark.conf
+++ b/themes/base2tone-space-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Space Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-space-dark.conf
+## blurb: duotone theme | warm space blue - medium orange
+
+
+#: The basic colors
+
+foreground #a1a1b5
+background #24242e
+selection_foreground #a1a1b5
+selection_background #333342
+
+
+#: Cursor colors
+
+cursor #b25424
+cursor_text_color #24242e
+
+
+#: URL underline color when hovering with mouse
+
+url_color #cecee3
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #515167
+inactive_border_color #24242e
+bell_border_color #5151e6
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #333342
+macos_titlebar_color #333342
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbf9f9
+active_tab_background #24242e
+inactive_tab_foreground #b1a9a5
+inactive_tab_background #333342
+tab_bar_background #333342
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #24242e
+mark1_background #6363ee
+mark2_foreground #24242e
+mark2_background #8e8580
+mark3_foreground #24242e
+mark3_background #cb5c25
+
+
+#: The basic 16 colors
+
+#: black
+color0 #24242e
+color8 #5b5b76
+
+#: red
+color1 #7676f4
+color9 #f37b3f
+
+#: green
+color2 #ec7336
+color10 #333342
+
+#: yellow
+color3 #fe8c52
+color11 #515167
+
+#: blue
+color4 #767693
+color12 #737391
+
+#: magenta
+color5 #ec7336
+color13 #cecee3
+
+#: cyan
+color6 #8a8aad
+color14 #e66e33
+
+#: white
+color7 #a1a1b5
+color15 #ebebff

--- a/themes/base2tone-suburb-dark.conf
+++ b/themes/base2tone-suburb-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base2Tone Suburb Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base2Tone-kitty/blob/main/themes/base2tone-suburb-dark.conf
+## blurb: duotone theme | warm blue - bright pink
+
+
+#: The basic colors
+
+foreground #878ba6
+background #1e202f
+selection_foreground #878ba6
+selection_background #292c3d
+
+
+#: Cursor colors
+
+cursor #d14781
+cursor_text_color #1e202f
+
+
+#: URL underline color when hovering with mouse
+
+url_color #d2d8fe
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #444864
+inactive_border_color #1e202f
+bell_border_color #5165e6
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #292c3d
+macos_titlebar_color #292c3d
+
+
+#: Tab bar colors
+
+active_tab_foreground #fbf9fa
+active_tab_background #1e202f
+inactive_tab_foreground #b0a6aa
+inactive_tab_background #292c3d
+tab_bar_background #292c3d
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #1e202f
+mark1_background #6375ee
+mark2_foreground #1e202f
+mark2_background #8d8186
+mark3_foreground #1e202f
+mark3_background #e44e8c
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1e202f
+color8 #4f5472
+
+#: red
+color1 #7586f5
+color9 #fe81b5
+
+#: green
+color2 #fb6fa9
+color10 #292c3d
+
+#: yellow
+color3 #ffb3d2
+color11 #444864
+
+#: blue
+color4 #8696fd
+color12 #5b6080
+
+#: magenta
+color5 #fb6fa9
+color13 #d2d8fe
+
+#: cyan
+color6 #a0acfe
+color14 #f764a1
+
+#: white
+color7 #878ba6
+color15 #ebedff


### PR DESCRIPTION
These are dark versions of [Base2Tone](https://base2t.one) for kitty. I created a dedicated repo of [Base2Tone for kitty](https://github.com/atelierbram/Base2Tone-kitty), so people can seek out the light themes over there if they want to do so.