### PR TITLE
added 7 Base4Tone dark themes

### DIFF
--- a/themes/base4tone-classic-d-dark.conf
+++ b/themes/base4tone-classic-d-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Classic_D Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-classic-d-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #eeede8
+background #21211c
+selection_foreground #eeede8
+selection_background #171711
+
+
+#: Cursor colors
+
+cursor #85776f
+cursor_text_color #21211c
+
+
+#: URL underline color when hovering with mouse
+
+url_color #a48f04
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #f5c1a3
+inactive_border_color #21211c
+bell_border_color #69a404
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2c2b25
+macos_titlebar_color #2c2b25
+
+
+#: Tab bar colors
+
+active_tab_foreground #eeede8
+active_tab_background #21211c
+inactive_tab_foreground #85826f
+inactive_tab_background #38362e
+tab_bar_background #38362e
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #0d0907
+mark1_background #da6b2b
+mark2_foreground #0d0c07
+mark2_background #a48f04
+mark3_foreground #0b0d07
+mark3_background #69a404
+
+
+#: The basic 16 colors
+
+#: black
+color0 #21211c
+color8 #0d0c07
+
+#: red
+color1 #049582
+color9 #1cc4ae
+
+#: green
+color2 #da6b2b
+color10 #f0a57a
+
+#: yellow
+color3 #ee9968
+color11 #f5c1a3
+
+#: blue
+color4 #cfb617
+color12 #f6edb1
+
+#: magenta
+color5 #82c115
+color13 #95dc18
+
+#: cyan
+color6 #e6854d
+color14 #f2e58c
+
+#: white
+color7 #eeede8
+color15 #f9f8f6

--- a/themes/base4tone-classic-i-dark.conf
+++ b/themes/base4tone-classic-i-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Classic_I Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-classic-i-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #e8ede9
+background #1d201d
+selection_foreground #e8ede9
+selection_background #121713
+
+
+#: Cursor colors
+
+cursor #83856f
+cursor_text_color #1d201d
+
+
+#: URL underline color when hovering with mouse
+
+url_color #0da51f
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #e6f28c
+inactive_border_color #1d201d
+bell_border_color #1398aa
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #272b27
+macos_titlebar_color #272b27
+
+
+#: Tab bar colors
+
+active_tab_foreground #e8ede9
+active_tab_background #1d201d
+inactive_tab_foreground #748176
+inactive_tab_background #303631
+tab_bar_background #303631
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #0d0d07
+mark1_background #91a404
+mark2_foreground #080d08
+mark2_background #0da51f
+mark3_foreground #070d0d
+mark3_background #1398aa
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1d201d
+color8 #080d08
+
+#: red
+color1 #5c6feb
+color9 #929ff7
+
+#: green
+color2 #91a404
+color10 #cee61a
+
+#: yellow
+color3 #c5dc18
+color11 #e6f28c
+
+#: blue
+color4 #24cc38
+color12 #b5f2bc
+
+#: magenta
+color5 #23b4c7
+color13 #3ccadd
+
+#: cyan
+color6 #adc115
+color14 #97eda1
+
+#: white
+color7 #e8ede9
+color15 #f6f9f6

--- a/themes/base4tone-classic-p-dark.conf
+++ b/themes/base4tone-classic-p-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Classic_P Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-classic-p-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #e8e8ee
+background #1c1d21
+selection_foreground #e8e8ee
+selection_background #111217
+
+
+#: Cursor colors
+
+cursor #6a878a
+cursor_text_color #1c1d21
+
+
+#: URL underline color when hovering with mouse
+
+url_color #6577ec
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #a4e6ef
+inactive_border_color #1c1d21
+bell_border_color #9263e3
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #25262c
+macos_titlebar_color #25262c
+
+
+#: Tab bar colors
+
+active_tab_foreground #e8e8ee
+active_tab_background #1c1d21
+inactive_tab_foreground #6f7285
+inactive_tab_background #2e3038
+tab_bar_background #2e3038
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #070d0d
+mark1_background #1398aa
+mark2_foreground #07080d
+mark2_background #6577ec
+mark3_foreground #09070d
+mark3_background #9263e3
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1c1d21
+color8 #07080d
+
+#: red
+color1 #c039d5
+color9 #db75eb
+
+#: green
+color2 #1398aa
+color10 #5ad2e2
+
+#: yellow
+color3 #3ccadd
+color11 #a4e6ef
+
+#: blue
+color4 #929ff7
+color12 #d0d5fb
+
+#: magenta
+color5 #a57af0
+color13 #b792f6
+
+#: cyan
+color6 #23b4c7
+color14 #c6cdfb
+
+#: white
+color7 #e8e8ee
+color15 #f6f6f9

--- a/themes/base4tone-classic-s-dark.conf
+++ b/themes/base4tone-classic-s-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Classic_S Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-classic-s-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #ebe8ed
+background #1f1d20
+selection_foreground #ebe8ed
+selection_background #151217
+
+
+#: Cursor colors
+
+cursor #767481
+cursor_text_color #1f1d20
+
+
+#: URL underline color when hovering with mouse
+
+url_color #aa52e0
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #d1cbfb
+inactive_border_color #1f1d20
+bell_border_color #dd40a4
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #29272b
+macos_titlebar_color #29272b
+
+
+#: Tab bar colors
+
+active_tab_foreground #ebe8ed
+active_tab_background #1f1d20
+inactive_tab_foreground #7c7481
+inactive_tab_background #343036
+tab_bar_background #343036
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #08070d
+mark1_background #7e70e6
+mark2_foreground #0b070d
+mark2_background #aa52e0
+mark3_foreground #0d070b
+mark3_background #dd40a4
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1f1d20
+color8 #0b070d
+
+#: red
+color1 #d64f3d
+color9 #eb8275
+
+#: green
+color2 #7e70e6
+color10 #b7aff8
+
+#: yellow
+color3 #aba1f7
+color11 #d1cbfb
+
+#: blue
+color4 #c27eed
+color12 #e6c8f9
+
+#: magenta
+color5 #e963b8
+color13 #f17ec7
+
+#: cyan
+color6 #9488f2
+color14 #e0baf7
+
+#: white
+color7 #ebe8ed
+color15 #f8f6f9

--- a/themes/base4tone-classic-w-dark.conf
+++ b/themes/base4tone-classic-w-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Classic_W Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-classic-w-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #ede8ea
+background #201d1e
+selection_foreground #ede8ea
+selection_background #161314
+
+
+#: Cursor colors
+
+cursor #7f7481
+cursor_text_color #201d1e
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dd407c
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #edb1f6
+inactive_border_color #201d1e
+bell_border_color #de5745
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2b2728
+macos_titlebar_color #2b2728
+
+
+#: Tab bar colors
+
+active_tab_foreground #ede8ea
+active_tab_background #201d1e
+inactive_tab_foreground #817479
+inactive_tab_background #363032
+tab_bar_background #363032
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #0c070d
+mark1_background #ca45de
+mark2_foreground #0d080a
+mark2_background #dd407c
+mark3_foreground #0d0807
+mark3_background #de5745
+
+
+#: The basic 16 colors
+
+#: black
+color0 #201d1e
+color8 #0d080a
+
+#: red
+color1 #b87305
+color9 #e6971a
+
+#: green
+color2 #ca45de
+color10 #e691f3
+
+#: yellow
+color3 #e17ef1
+color11 #edb1f6
+
+#: blue
+color4 #eb75a2
+color12 #f8bfd5
+
+#: magenta
+color5 #e97263
+color13 #f18c7e
+
+#: cyan
+color6 #d763e9
+color14 #f6b1cc
+
+#: white
+color7 #ede8ea
+color15 #f9f6f7

--- a/themes/base4tone-modern-n-dark.conf
+++ b/themes/base4tone-modern-n-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Modern_N Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-modern-n-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #e8ebee
+background #1a2023
+selection_foreground #e8ebee
+selection_background #111517
+
+
+#: Cursor colors
+
+cursor #85826f
+cursor_text_color #1a2023
+
+
+#: URL underline color when hovering with mouse
+
+url_color #0c95e4
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #f2e58c
+inactive_border_color #1a2023
+bell_border_color #6577ec
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #232a2f
+macos_titlebar_color #232a2f
+
+
+#: Tab bar colors
+
+active_tab_foreground #e8ebee
+active_tab_background #1a2023
+inactive_tab_foreground #687f8d
+inactive_tab_background #2b353b
+tab_bar_background #2b353b
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #0d0c07
+mark1_background #a48f04
+mark2_foreground #070b0d
+mark2_background #0c95e4
+mark3_foreground #07080d
+mark3_background #6577ec
+
+
+#: The basic 16 colors
+
+#: black
+color0 #1a2023
+color8 #070b0d
+
+#: red
+color1 #d53975
+color9 #eb75a2
+
+#: green
+color2 #a48f04
+color10 #e6ca1a
+
+#: yellow
+color3 #dcc218
+color11 #f2e58c
+
+#: blue
+color4 #47b5f5
+color12 #bbe4fb
+
+#: magenta
+color5 #8493f6
+color13 #a0acf8
+
+#: cyan
+color6 #c1aa15
+color14 #b1e0fb
+
+#: white
+color7 #e8ebee
+color15 #f6f8f9

--- a/themes/base4tone-modern-w-dark.conf
+++ b/themes/base4tone-modern-w-dark.conf
@@ -1,0 +1,95 @@
+# vim:ft=kitty
+
+## name: Base4Tone_Modern_W Dark
+## author: Bram de Haan (https://github.com/atelierbram)
+## license: MIT
+## upstream: https://github.com/atelierbram/Base4Tone-kitty/blob/main/themes/base4tone-modern-w-dark.conf
+## blurb: theme with limited color palette
+
+
+#: The basic colors
+
+foreground #ede8ea
+background #201d1e
+selection_foreground #ede8ea
+selection_background #161314
+
+
+#: Cursor colors
+
+cursor #6a878a
+cursor_text_color #201d1e
+
+
+#: URL underline color when hovering with mouse
+
+url_color #dd407c
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color #a4e6ef
+inactive_border_color #201d1e
+bell_border_color #de5745
+visual_bell_color none
+
+
+#: OS Window titlebar colors
+
+wayland_titlebar_color #2b2728
+macos_titlebar_color #2b2728
+
+
+#: Tab bar colors
+
+active_tab_foreground #ede8ea
+active_tab_background #201d1e
+inactive_tab_foreground #817479
+inactive_tab_background #363032
+tab_bar_background #363032
+tab_bar_margin_color none
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #070d0d
+mark1_background #1398aa
+mark2_foreground #0d080a
+mark2_background #dd407c
+mark3_foreground #0d0807
+mark3_background #de5745
+
+
+#: The basic 16 colors
+
+#: black
+color0 #201d1e
+color8 #0d080a
+
+#: red
+color1 #21a00d
+color9 #39c723
+
+#: green
+color2 #1398aa
+color10 #5ad2e2
+
+#: yellow
+color3 #3ccadd
+color11 #a4e6ef
+
+#: blue
+color4 #eb75a2
+color12 #f8bfd5
+
+#: magenta
+color5 #e97263
+color13 #f18c7e
+
+#: cyan
+color6 #23b4c7
+color14 #f6b1cc
+
+#: white
+color7 #ede8ea
+color15 #f9f6f7


### PR DESCRIPTION
These are 7 dark versions of some of the [Base4Tone](https://atelierbram.github.io/syntax-highlighting/base4tone/) themes for kitty. I created a dedicated repo of [Base4Tone for kitty](https://github.com/atelierbram/Base4Tone-kitty), so people can seek out the other dark themes and the light themes over there as well if they want to do so.