### PR TITLE
Add other themes in the nightfox.nvim theme collection.

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -656,6 +656,16 @@
         "num_settings": 20
     },
     {
+        "author": "EdenEast",
+        "blurb": "Carbonfox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Carbonfox.conf",
+        "is_dark": true,
+        "license": "MIT",
+        "name": "Carbonfox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/carbonfox/kitty.conf"
+    },
+    {
         "author": "Pocco81 (https://github.com/Pocco81)",
         "blurb": "Soothing pastel theme for the high-spirited!",
         "file": "themes/Catppuccin-Frappe.conf",
@@ -820,6 +830,24 @@
         "num_settings": 21
     },
     {
+        "author": "EdenEast",
+        "blurb": "Dawnfox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Dawnfox.conf",
+        "license": "MIT",
+        "name": "Dawnfox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/dawnfox/kitty.conf"
+    },
+    {
+        "author": "EdenEast",
+        "blurb": "Dayfox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Dayfox.conf",
+        "license": "MIT",
+        "name": "Dayfox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/dayfox/kitty.conf"
+    },
+    {
         "author": "Kovid Goyal",
         "blurb": "This theme uses all default settings from kitty.  Use it to easily restore defaults.",
         "file": "themes/default.conf",
@@ -897,6 +925,16 @@
         "is_dark": true,
         "name": "Duotone Dark",
         "num_settings": 21
+    },
+    {
+        "author": "EdenEast",
+        "blurb": "Duskfox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Duskfox.conf",
+        "is_dark": true,
+        "license": "MIT",
+        "name": "Duskfox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/duskfox/kitty.conf"
     },
     {
         "file": "themes/ENCOM.conf",
@@ -1773,6 +1811,16 @@
         "upstream": "https://www.nordtheme.com/"
     },
     {
+        "author": "EdenEast",
+        "blurb": "Nordfox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Nordfox.conf",
+        "is_dark": true,
+        "license": "MIT",
+        "name": "Nordfox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/nordfox/kitty.conf"
+    },
+    {
         "file": "themes/Nova.conf",
         "is_dark": true,
         "name": "Nova",
@@ -2234,6 +2282,16 @@
         "name": "Tender",
         "num_settings": 18,
         "upstream": "https://github.com/CompEng0001/tender-kitty/raw/main/theme.conf"
+    },
+    {
+        "author": "EdenEast",
+        "blurb": "Terafox theme from the neovim colorscheme nightfox.nvim.",
+        "file": "themes/Terafox.conf",
+        "is_dark": true,
+        "license": "MIT",
+        "name": "Terafox",
+        "num_settings": 32,
+        "upstream": "https://github.com/EdenEast/nightfox.nvim/blob/main/extra/terafox/kitty.conf"
     },
     {
         "file": "themes/Thayer_Bright.conf",

--- a/themes/Carbonfox.conf
+++ b/themes/Carbonfox.conf
@@ -1,0 +1,104 @@
+# vim:ft=kitty
+## name: Carbonfox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/carbonfox/kitty.conf
+## blurb: Carbonfox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #f2f4f8
+background                      #161616
+selection_foreground            #f2f4f8
+selection_background            #2a2a2a
+
+
+#: Cursor colors
+
+cursor                          #f2f4f8
+cursor_text_color               #161616
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #25be6a
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #78a9ff
+inactive_border_color           #535353
+bell_border_color               #3ddbd9
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #0c0c0c
+active_tab_background           #78a9ff
+inactive_tab_foreground         #6e6f70
+inactive_tab_background         #2a2a2a
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #282828
+color8 #484848
+
+#: red
+color1 #ee5396
+color9 #f16da6
+
+#: green
+color2  #25be6a
+color10 #46c880
+
+#: yellow
+color3  #ebcb8b
+color11 #f0d399
+
+#: blue
+color4  #78a9ff
+color12 #8cb6ff
+
+#: magenta
+color5  #be95ff
+color13 #c8a5ff
+
+#: cyan
+color6  #33b1ff
+color14 #52bdff
+
+#: white
+color7  #dfdfe0
+color15 #e4e4e5
+
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #3ddbd9
+color17 #ff7eb6

--- a/themes/Dawnfox.conf
+++ b/themes/Dawnfox.conf
@@ -1,0 +1,103 @@
+# vim:ft=kitty
+## name: Dawnfox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/dawnfox/kitty.conf
+## blurb: Dawnfox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #575279
+background                      #faf4ed
+selection_foreground            #575279
+selection_background            #d0d8d8
+
+
+#: Cursor colors
+
+cursor                          #575279
+cursor_text_color               #faf4ed
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #618774
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #286983
+inactive_border_color           #bdbfc9
+bell_border_color               #d7827e
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #ebe5df
+active_tab_background           #286983
+inactive_tab_foreground         #9893a5
+inactive_tab_background         #d0d8d8
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #575279
+color8 #5f5695
+
+#: red
+color1 #b4637a
+color9 #c26d85
+
+#: green
+color2  #618774
+color10 #629f81
+
+#: yellow
+color3  #ea9d34
+color11 #eea846
+
+#: blue
+color4  #286983
+color12 #2d81a3
+
+#: magenta
+color5  #907aa9
+color13 #9a80b9
+
+#: cyan
+color6  #56949f
+color14 #5ca7b4
+
+#: white
+color7  #e5e9f0
+color15 #e6ebf3
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #d7827e
+color17 #d685af

--- a/themes/Dayfox.conf
+++ b/themes/Dayfox.conf
@@ -1,0 +1,103 @@
+# vim:ft=kitty
+## name: Dayfox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/dayfox/kitty.conf
+## blurb: Dayfox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #3d2b5a
+background                      #f6f2ee
+selection_foreground            #3d2b5a
+selection_background            #e7d2be
+
+
+#: Cursor colors
+
+cursor                          #3d2b5a
+cursor_text_color               #f6f2ee
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #396847
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #2848a9
+inactive_border_color           #aab0ad
+bell_border_color               #955f61
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #e4dcd4
+active_tab_background           #2848a9
+inactive_tab_foreground         #837a72
+inactive_tab_background         #e7d2be
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #352c24
+color8 #534c45
+
+#: red
+color1 #a5222f
+color9 #b3434e
+
+#: green
+color2  #396847
+color10 #577f63
+
+#: yellow
+color3  #ac5402
+color11 #b86e28
+
+#: blue
+color4  #286983
+color12 #2d81a3
+
+#: magenta
+color5  #6e33ce
+color13 #8452d5
+
+#: cyan
+color6  #287980
+color14 #488d93
+
+#: white
+color7  #f2e9e1
+color15 #f4ece6
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #955f61
+color17 #a440b5

--- a/themes/Duskfox.conf
+++ b/themes/Duskfox.conf
@@ -1,0 +1,103 @@
+# vim:ft=kitty
+## name: Duskfox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/duskfox/kitty.conf
+## blurb: Duskfox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #e0def4
+background                      #232136
+selection_foreground            #e0def4
+selection_background            #433c59
+
+
+#: Cursor colors
+
+cursor                          #e0def4
+cursor_text_color               #232136
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #a3be8c
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #569fba
+inactive_border_color           #4b4673
+bell_border_color               #ea9a97
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #191726
+active_tab_background           #569fba
+inactive_tab_foreground         #817c9c
+inactive_tab_background         #433c59
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #393552
+color8 #47407d
+
+#: red
+color1 #eb6f92
+color9 #f083a2
+
+#: green
+color2  #a3be8c
+color10 #b1d196
+
+#: yellow
+color3  #f6c177
+color11 #f9cb8c
+
+#: blue
+color4  #569fba
+color12 #65b1cd
+
+#: magenta
+color5  #c4a7e7
+color13 #ccb1ed
+
+#: cyan
+color6  #9ccfd8
+color14 #a6dae3
+
+#: white
+color7  #e0def4
+color15 #e2e0f7
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #ea9a97
+color17 #eb98c3

--- a/themes/Nordfox.conf
+++ b/themes/Nordfox.conf
@@ -1,0 +1,104 @@
+# vim:ft=kitty
+## name: Nordfox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/nordfox/kitty.conf
+## blurb: Nordfox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #cdcecf
+background                      #2e3440
+selection_foreground            #cdcecf
+selection_background            #3e4a5b
+
+
+#: Cursor colors
+
+cursor                          #cdcecf
+cursor_text_color               #2e3440
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #a3be8c
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #81a1c1
+inactive_border_color           #5a657d
+bell_border_color               #c9826b
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #232831
+active_tab_background           #81a1c1
+inactive_tab_foreground         #60728a
+inactive_tab_background         #3e4a5b
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #3b4252
+color8 #465780
+
+#: red
+color1 #bf616a
+color9 #d06f79
+
+#: green
+color2  #a3be8c
+color10 #b1d196
+
+#: yellow
+color3  #ebcb8b
+color11 #f0d399
+
+#: blue
+color4  #81a1c1
+color12 #8cafd2
+
+#: magenta
+color5  #b48ead
+color13 #c895bf
+
+#: cyan
+color6  #88c0d0
+color14 #93ccdc
+
+#: white
+color7  #e5e9f0
+color15 #e7ecf4
+
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #c9826b
+color17 #bf88bc

--- a/themes/Terafox.conf
+++ b/themes/Terafox.conf
@@ -1,0 +1,104 @@
+# vim:ft=kitty
+## name: Terafox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/terafox/kitty.conf
+## blurb: Terafox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #e6eaea
+background                      #152528
+selection_foreground            #e6eaea
+selection_background            #293e40
+
+
+#: Cursor colors
+
+cursor                          #e6eaea
+cursor_text_color               #152528
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #7aa4a1
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #5a93aa
+inactive_border_color           #2d4f56
+bell_border_color               #ff8349
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #0f1c1e
+active_tab_background           #5a93aa
+inactive_tab_foreground         #6d7f8b
+inactive_tab_background         #293e40
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #2f3239
+color8 #4e5157
+
+#: red
+color1 #e85c51
+color9 #eb746b
+
+#: green
+color2  #7aa4a1
+color10 #8eb2af
+
+#: yellow
+color3  #fda47f
+color11 #fdb292
+
+#: blue
+color4  #5a93aa
+color12 #73a3b7
+
+#: magenta
+color5  #ad5c7c
+color13 #b97490
+
+#: cyan
+color6  #a1cdd8
+color14 #afd4de
+
+#: white
+color7  #ebebeb
+color15 #eeeeee
+
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #ff8349
+color17 #cb7985


### PR DESCRIPTION
Currently only `Nightfox.conf` is available. This PR adds other themes (foxes) from the neovim colorscheme [nightfox.nvim](https://github.com/EdenEast/nightfox.nvim).

I have also run the `gen-metadata.py` script to update `themes.json`.