### PR TITLE
Add noirbuddy oxide theme

### DIFF
--- a/themes/noirbuddy-oxide.conf
+++ b/themes/noirbuddy-oxide.conf
@@ -1,0 +1,84 @@
+## name: noirbuddy-oxide
+## author: Dimitar Dimitrov (https://github.com/n1ghtmare)
+## license: MIT
+## blurb: A dark minimal theme based on the neovim noirbuddy theme system with a touch of oxide
+
+
+#: The basic colors
+
+foreground                      #d5d5d5
+background                      #070e11
+selection_foreground            #070e11
+selection_background            #b0b0b0
+
+
+#: Cursor colors
+
+cursor              #00d992
+cursor_text_color   background
+
+
+#: URL underline color when hovering with mouse
+
+url_color           #b0b0b0
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color     #00d992
+inactive_border_color   #0e1618
+bell_border_color       #00d992
+
+
+#: Tab bar colors
+
+active_tab_foreground   #d5d5d5
+active_tab_background   #070e11
+inactive_tab_foreground #b4b4b4
+inactive_tab_background #323232
+
+
+#: The basic 16 colors
+
+#: black
+color0 #070e11
+color8 #737373
+
+#: red
+color1 #fa5e86
+color9 #ff0088
+
+#: green
+color2  #00d992
+color10 #00ff77
+
+#: yellow
+color3  #ffffff
+color11 #FDFDFD
+
+#: blue
+color4  #b0b0b0
+color12 #BEBEBE
+
+#: magenta
+color5  #7a7a7a
+color13 #939393
+
+#: cyan
+color6  #787878
+color14 #919191
+
+#: white
+color7  #d5d5d5
+color15 #f5f5f5
+
+
+#: Colors for marks (marked text in the terminal)
+
+mark1_foreground #121212
+mark1_background #070e11
+
+mark2_foreground #121212
+mark2_background #7a7a7a
+
+mark3_foreground #121212
+mark3_background #ffffff


### PR DESCRIPTION
A monochrome theme, based on the neovim [noirbuddy theme system](https://github.com/jesseleite/nvim-noirbuddy), namely the Oxide preset.