### PR TITLE
Add blueberry-mango theme

### DIFF
--- a/themes/blueberry-mango.conf
+++ b/themes/blueberry-mango.conf
@@ -2,7 +2,7 @@
 ## author: janbridley
 ## license: MIT
 ## upstream: https://github.com/janbridley/blueberry-mango/blob/main/kitty/blueberry-mango.conf
-## blurb: Pastel dark theme optimized to work with mixed deuteranomaly-protanomaly
+## blurb: Pastel dark theme optimized to work with mixed deuteranomaly-tritanomaly
 ## colorblindness.
 
 foreground                      #feffe0

--- a/themes/blueberry-mango.conf
+++ b/themes/blueberry-mango.conf
@@ -1,0 +1,63 @@
+## name: Blueberry Mango
+## author: janbridley
+## license: MIT
+## upstream: https://github.com/janbridley/blueberry-mango/blob/main/kitty/blueberry-mango.conf
+## blurb: Pastel dark theme optimized to work with mixed deuteranomaly-protanomaly
+## colorblindness.
+
+foreground                      #feffe0
+background                      #181321
+selection_foreground            #f4f4f4
+selection_background            #1e0623
+
+cursor                          #d28133
+cursor_text_color               #fefefe
+
+url_color                       #ea9649
+
+active_border_color             #54b99d
+inactive_border_color           #171320
+bell_border_color               #f0a2a3
+visual_bell_color               none
+
+wayland_titlebar_color          #1e1e2e
+macos_titlebar_color            #1e1e2e
+
+
+active_tab_foreground           #feffe0
+active_tab_background           #171320
+inactive_tab_foreground         #4a5060
+inactive_tab_background         #171320
+tab_bar_background              #171320
+
+#: black
+color0 #16141e
+color8 #4a5060
+
+#: red
+color1 #ed7481
+color9 #f0a2a3
+
+#: green
+color2  #54b99d
+color10 #a0c180
+
+#: yellow
+color3  #e0c750
+color11 #f5e47d
+
+#: blue
+color4  #6ee4de
+color12 #abfcf3
+
+#: magenta
+color5  #ca476a
+color13 #cc75d0
+
+#: cyan
+color6  #6fb3bf
+color14 #c7f1fc
+
+#: white
+color7  #f1f1f1
+color15 #fefefe


### PR DESCRIPTION
I have added a theme file for Blueberry Mango, a pastel dark theme that I designed to help with my mixed red-green and blue-yellow colorblindness. It is loosely based on the [Blueberry Banana theme from remmina](https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/remmina/Banana%20Blueberry.colors), but has been modified to provide better contrast between color pairs and the background.

An [upstream repo](https://github.com/janbridley/blueberry-mango) has also been created to house the theme, with an example image and a few README examples.