### PR TITLE
Better `git` colors for `noirbuddy-oxide`

### DIFF
--- a/themes/noirbuddy-oxide.conf
+++ b/themes/noirbuddy-oxide.conf
@@ -60,7 +60,7 @@ color4  #b0b0b0
 color12 #BEBEBE
 
 #: magenta
-color5  #7a7a7a
+color5  #90a7f8
 color13 #939393
 
 #: cyan


### PR DESCRIPTION
This provides a better contrast color for both `git` and `jj` while still within the `oxide` color scheme.