### PR TITLE
Bogster (Dark): improve color contrast and readability

### DIFF
--- a/themes/bogster_dark.conf
+++ b/themes/bogster_dark.conf
@@ -6,20 +6,20 @@
 ## blurb: A warm, muted dark theme with earthy, cozy vibes
 
 #: The basic colors
-foreground                      #c6b8ad
+foreground                      #c6bfba
 background                      #161c23
-selection_foreground            #b6b6c9
-selection_background            #2d3946
+selection_foreground            #d2c6b8
+selection_background            #252f3b
 
 #: Cursor colors
-cursor                          #e5ded6
+cursor                          #dfd7d0
 cursor_text_color               #161c23
 
 #: URL underline color when hovering with mouse
-url_color                       #59dcb7
+url_color                       #6fcc4c
 
 #: kitty window border colors and terminal bell colors
-active_border_color             #7fdc59
+active_border_color             #59dcb7
 inactive_border_color           #313f4e
 bell_border_color               #dc7759
 visual_bell_color               none
@@ -30,17 +30,17 @@ macos_titlebar_color            system
 
 #: Tab bar colors
 active_tab_background           #161c23
-active_tab_foreground           #e5ded6
+active_tab_foreground           #dfd7d0
 inactive_tab_background         #232d38
-inactive_tab_foreground         #b6b6c9
+inactive_tab_foreground         #d2c6b8
 tab_bar_background              #161c23
 tab_bar_margin_color            none
 
 #: Colors for marks (marked text in the terminal)
 mark1_foreground                #161c23
-mark1_background                #59dcb7
+mark1_background                #23a580
 mark2_foreground                #161c23
-mark2_background                #dcb659
+mark2_background                #cca734
 mark3_foreground                #161c23
 mark3_background                #b759dc
 
@@ -48,32 +48,32 @@ mark3_background                #b759dc
 
 #: black
 color0                          #161c23
-color8                          #5a738c
+color8                          #45576d
 
 #: red
-color1                          #d32c5d
-color9                          #dc597f
+color1                          #bd2853
+color9                          #db567c
 
 #: green
-color2                          #57a331
-color10                         #7fdc59
+color2                          #549d2f
+color10                         #6fcc4c
 
 #: yellow
-color3                          #dcb659
-color11                         #e5c86b
+color3                          #cca734
+color11                         #dfc26b
 
 #: blue
-color4                          #36b2d4
-color12                         #5bcceb
+color4                          #248baa
+color12                         #4fbadb
 
-# #: magenta
+#: magenta
 color5                          #b759dc
-color13                         #d393ea
+color13                         #dc59c0
 
 #: cyan
-color6                          #59dcb7
-color14                         #7cebc9
+color6                          #23a580
+color14                         #59dcb7
 
 #: white
-color7                          #c6b8ad
-color15                         #e5ded6
+color7                          #c6bfba
+color15                         #dfd7d0


### PR DESCRIPTION
This improves the Bogster (Dark) theme for better readability in real terminal use.

The original Vim-based colors had poor contrast in certain situations, e.g.:
- In PowerShell 7, `Get-ChildItem` uses blue background + white foreground, which was hard to read.

I adjusted brightness (mainly), plus some saturation/hue changes, to:
- Keep the original warm, earthy style of Bogster
- Significantly improve foreground readability on various background colors

All common terminal foreground/background combinations have been re-tested.

Thanks for reviewing ~