### PR TITLE
Add Serendipity and Sequoia theme families

### DIFF
--- a/themes/Sequoia_Monochrome_Dark.conf
+++ b/themes/Sequoia_Monochrome_Dark.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Monochrome Dark
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-monochrome-dark.conf
+## blurb: Sequoia Monochrome Dark from the Sequoia theme family.
+
+background #0f1014
+foreground #868690
+cursor #7c829d
+selection_background #817c9c26
+selection_foreground #868690
+color0 #131317
+color1 #999eb2
+color2 #626983
+color3 #d3d5de
+color4 #7c829d
+color5 #e2e4ed
+color6 #b6bac8
+color7 #868690
+color8 #575861
+color9 #999eb2
+color10 #626983
+color11 #d3d5de
+color12 #7c829d
+color13 #e2e4ed
+color14 #b6bac8
+color15 #868690

--- a/themes/Sequoia_Monochrome_Light.conf
+++ b/themes/Sequoia_Monochrome_Light.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Monochrome Light
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-monochrome-light.conf
+## blurb: Sequoia Monochrome Light from the Sequoia theme family.
+
+background #edeef2
+foreground #282930
+cursor #5f6370
+selection_background #817c9c38
+selection_foreground #282930
+color0 #d4d5dc
+color1 #525666
+color2 #2e3038
+color3 #50535e
+color4 #5f6370
+color5 #25262d
+color6 #454752
+color7 #282930
+color8 #42434e
+color9 #525666
+color10 #2e3038
+color11 #50535e
+color12 #5f6370
+color13 #25262d
+color14 #454752
+color15 #282930

--- a/themes/Sequoia_Moonlight_Dark.conf
+++ b/themes/Sequoia_Moonlight_Dark.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Moonlight Dark
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-moonlight-dark.conf
+## blurb: Sequoia Moonlight Dark from the Sequoia theme family.
+
+background #0f1014
+foreground #868690
+cursor #c58fff
+selection_background #817c9c26
+selection_foreground #868690
+color0 #131317
+color1 #f58ee0
+color2 #8eb6f5
+color3 #9898a6
+color4 #c58fff
+color5 #fdfdfe
+color6 #ffbb88
+color7 #868690
+color8 #575861
+color9 #f58ee0
+color10 #8eb6f5
+color11 #9898a6
+color12 #c58fff
+color13 #fdfdfe
+color14 #ffbb88
+color15 #868690

--- a/themes/Sequoia_Moonlight_Light.conf
+++ b/themes/Sequoia_Moonlight_Light.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Moonlight Light
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-moonlight-light.conf
+## blurb: Sequoia Moonlight Light from the Sequoia theme family.
+
+background #edeef2
+foreground #282930
+cursor #9a5fd9
+selection_background #817c9c38
+selection_foreground #282930
+color0 #d4d5dc
+color1 #c94da8
+color2 #4a85d4
+color3 #6a6a78
+color4 #9a5fd9
+color5 #282930
+color6 #d9884a
+color7 #282930
+color8 #42434e
+color9 #c94da8
+color10 #4a85d4
+color11 #6a6a78
+color12 #9a5fd9
+color13 #282930
+color14 #d9884a
+color15 #282930

--- a/themes/Sequoia_Retro_Dark.conf
+++ b/themes/Sequoia_Retro_Dark.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Retro Dark
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-retro-dark.conf
+## blurb: Sequoia Retro Dark from the Sequoia theme family.
+
+background #0f1014
+foreground #868690
+cursor #5c87a4
+selection_background #817c9c26
+selection_foreground #868690
+color0 #131317
+color1 #829fa7
+color2 #648f68
+color3 #da674b
+color4 #5c87a4
+color5 #e8b246
+color6 #a27e57
+color7 #868690
+color8 #575861
+color9 #e8b246
+color10 #648f68
+color11 #da674b
+color12 #5c87a4
+color13 #829fa7
+color14 #a27e57
+color15 #868690

--- a/themes/Sequoia_Retro_Light.conf
+++ b/themes/Sequoia_Retro_Light.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Sequoia Retro Light
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Sequoia-Theme/kitty/main/sequoia-retro-light.conf
+## blurb: Sequoia Retro Light from the Sequoia theme family.
+
+background #edeef2
+foreground #282930
+cursor #456a82
+selection_background #817c9c38
+selection_foreground #282930
+color0 #d4d5dc
+color1 #5f7982
+color2 #4a704e
+color3 #bf5238
+color4 #456a82
+color5 #c99730
+color6 #8a6539
+color7 #282930
+color8 #42434e
+color9 #c99730
+color10 #4a704e
+color11 #bf5238
+color12 #456a82
+color13 #5f7982
+color14 #8a6539
+color15 #282930

--- a/themes/Serendipity_Midnight.conf
+++ b/themes/Serendipity_Midnight.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Serendipity Midnight
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Serendipity-Theme/kitty/main/serendipity-midnight.conf
+## blurb: Serendipity Midnight from the Serendipity theme family.
+
+background #151726
+foreground #dee0ef
+cursor #d1918f
+selection_background #6B6D7C33
+selection_foreground #dee0ef
+color0 #232534
+color1 #ee8679
+color2 #5ba2d0
+color3 #a78bfa
+color4 #94b8ff
+color5 #9ccfd8
+color6 #f8d2c9
+color7 #dee0ef
+color8 #8d8f9e
+color9 #ee8679
+color10 #5ba2d0
+color11 #a78bfa
+color12 #94b8ff
+color13 #9ccfd8
+color14 #f8d2c9
+color15 #dee0ef

--- a/themes/Serendipity_Morning.conf
+++ b/themes/Serendipity_Morning.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Serendipity Morning
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Serendipity-Theme/kitty/main/serendipity-morning.conf
+## blurb: Serendipity Morning from the Serendipity theme family.
+
+background #f6f7fb
+foreground #3f4363
+cursor #6d7296
+selection_background #5a567018
+selection_foreground #3f4363
+color0 #ccd0dc
+color1 #c25a4d
+color2 #2f7aab
+color3 #785fd0
+color4 #6288d8
+color5 #629aa5
+color6 #e58678
+color7 #3f4363
+color8 #505575
+color9 #c25a4d
+color10 #2f7aab
+color11 #785fd0
+color12 #6288d8
+color13 #629aa5
+color14 #e58678
+color15 #3f4363

--- a/themes/Serendipity_Sunset.conf
+++ b/themes/Serendipity_Sunset.conf
@@ -1,0 +1,28 @@
+# vim:ft=kitty
+## name: Serendipity Sunset
+## author: Micheal Andreuzza
+## license: MIT
+## upstream: https://raw.githubusercontent.com/Serendipity-Theme/kitty/main/serendipity-sunset.conf
+## blurb: Serendipity Sunset from the Serendipity theme family.
+
+background #202231
+foreground #dee0ef
+cursor #d1918f
+selection_background #6B6D7C26
+selection_foreground #dee0ef
+color0 #363847
+color1 #d1918f
+color2 #709bbd
+color3 #a392dc
+color4 #a0b6e8
+color5 #aac9d4
+color6 #d6b4b4
+color7 #dee0ef
+color8 #6b6d7c
+color9 #d1918f
+color10 #709bbd
+color11 #a392dc
+color12 #a0b6e8
+color13 #aac9d4
+color14 #d6b4b4
+color15 #dee0ef


### PR DESCRIPTION
## Summary
- Adds 3 Serendipity variants (Midnight, Morning, Sunset)
- Adds 6 Sequoia variants (Moonlight, Monochrome, Retro — dark and light)
- MIT licensed; upstream links point to Serendipity-Theme/kitty and Sequoia-Theme/kitty

## Test plan
- [ ] `kitten themes` lists the new themes
- [ ] Colors match upstream conf files

Made with [Cursor](https://cursor.com)