### PR TITLE
Add Konsole_Breeze_Dark

### DIFF
--- a/themes/Konsole_Breeze_Dark.conf
+++ b/themes/Konsole_Breeze_Dark.conf
@@ -1,0 +1,126 @@
+# vim:ft=kitty
+## name: Konsole Breeze Dark. 
+## author: Claes 
+## license: GPLv2
+## upstream: https://github.com/KDE/konsole/blob/master/data/color-schemes/Breeze.colorscheme
+## blurb: Breeze theme from the KDE Konsole terminal. Useful to match KDE Breeze dark theme.
+
+# Konsole currently only has a dark Breeze theme, called just "Breeze". 
+# When / if it adds a light theme, it can be added to kitty as well. 
+
+background #232627
+# [Background] Color=35,38,39
+# RGB(35,38,39) -> #232627
+
+selection_background #3daee9
+# No selection color exists in the Konsole scheme.
+# Chosen from [ForegroundIntense] and [Color4Intense]:
+# RGB(61,174,233) -> #3daee9
+# This is the canonical Breeze accent color.
+
+foreground #fcfcfc
+# [Foreground] Color=252,252,252
+# RGB(252,252,252) -> #fcfcfc
+
+selection_foreground #fcfcfc
+# Reuse foreground color for contrast against selection_background.
+
+cursor #fcfcfc
+# No cursor color in Konsole scheme.
+# Reuse [Foreground] Color=252,252,252.
+
+cursor_text_color #232627
+# Text shown under block cursor.
+# Reuse [Background] Color=35,38,39.
+
+url_color #3daee9
+# No URL color in Konsole scheme.
+# Reuse Breeze accent blue from [Color4Intense].
+
+color0 #232627
+# [Color0] Color=35,38,39
+# RGB(35,38,39) -> #232627
+
+color1 #ed1515
+# [Color1] Color=237,21,21
+# RGB(237,21,21) -> #ed1515
+
+color2 #11d116
+# [Color2] Color=17,209,22
+# RGB(17,209,22) -> #11d116
+
+color3 #f67400
+# [Color3] Color=246,116,0
+# RGB(246,116,0) -> #f67400
+
+color4 #1d99f3
+# [Color4] Color=29,153,243
+# RGB(29,153,243) -> #1d99f3
+
+color5 #9b59b6
+# [Color5] Color=155,89,182
+# RGB(155,89,182) -> #9b59b6
+
+color6 #1abc9c
+# [Color6] Color=26,188,156
+# RGB(26,188,156) -> #1abc9c
+
+color7 #fcfcfc
+# [Color7] Color=252,252,252
+# RGB(252,252,252) -> #fcfcfc
+
+color8 #7f8c8d
+# [Color0Intense] Color=127,140,141
+# RGB(127,140,141) -> #7f8c8d
+# ANSI bright black.
+
+color9 #c0392b
+# [Color1Intense] Color=192,57,43
+# RGB(192,57,43) -> #c0392b
+# ANSI bright red.
+
+color10 #1cdc9a
+# [Color2Intense] Color=28,220,154
+# RGB(28,220,154) -> #1cdc9a
+# ANSI bright green.
+
+color11 #fdbc4b
+# [Color3Intense] Color=253,188,75
+# RGB(253,188,75) -> #fdbc4b
+# ANSI bright yellow.
+
+color12 #3daee9
+# [Color4Intense] Color=61,174,233
+# RGB(61,174,233) -> #3daee9
+# ANSI bright blue and Breeze accent color.
+
+color13 #8e44ad
+# [Color5Intense] Color=142,68,173
+# RGB(142,68,173) -> #8e44ad
+# ANSI bright magenta.
+
+color14 #16a085
+# [Color6Intense] Color=22,160,133
+# RGB(22,160,133) -> #16a085
+# ANSI bright cyan.
+
+color15 #ffffff
+# [Color7Intense] Color=255,255,255
+# RGB(255,255,255) -> #ffffff
+# ANSI bright white.
+
+active_tab_background #3daee9
+# Not present in Konsole.
+# Chosen as the Breeze accent color ([Color4Intense]).
+
+active_tab_foreground #fcfcfc
+# Reuse foreground color for contrast.
+
+inactive_tab_background #31363b
+# [BackgroundFaint] Color=49,54,59
+# RGB(49,54,59) -> #31363b
+# This is also a common Breeze panel/background shade.
+
+inactive_tab_foreground #eff0f1
+# [ForegroundFaint] Color=239,240,241
+# RGB(239,240,241) -> #eff0f1


### PR DESCRIPTION
This is a port of the KDE Konsole terminal "Breeze" theme. Since KDE Plasma uses Breeze as official theme, it is useful to have in Kitty. Note that while KDE also has a light Breeze theme, Konsole does not have a light theme.. Therefore I am only contributing a dark theme with this PR. 